### PR TITLE
Automount of Graphs, add Get-GraphType cmdlet

### DIFF
--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.14.0'
+ModuleVersion = '0.15.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -169,33 +169,19 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @"
-# AutoGraphPS 0.14.0 Release Notes
-
-This release renames the ``PoshGraph`` module to ``AutoGraphPS``. See the release notes below for changes from the previous release.
-
-# AutoGraphPS 0.13.0 Release Notes
-
-This release includes app-only related features from PoshGraph-SDK 0.3.0 as well as argument completion for Graph URIs and graph names.
+# AutoGraphPS 0.15.0 Release Notes
 
 ## New Features
 
-* ``Get-GraphChildItem`` now supports app-only authentication with MS Graph through the ``New-GraphConnection`` and `Connect-Graph`` cmdlets
-* ``Set-GraphPrompt`` displays app + tenant information for app-only connections
-* ``Get-GraphChildItem`` now supports V1 token caching due to update to newer ``poshgraph-sdk`` dependency
-* ``Get-GraphChildItem``, ``Set-GraphLocation``, and ``Get-GraphUri`` now support auto-completion of Graph uri parameters once metadata has been processed
-8 ``Get-Graph``, ``Remove-Graph`` cmdlets support auto-completion of Graph name arguments
-* New ``-Force`` option for ``Set-GraphLocation`` let's you bypass the wait on metadata processing and set the location to the root of the specified graph.
-* New ``-Current`` option for ``Get-Graph`` to get the current Graph
-* Include tenant information in ``Get-Graph`` result
-* Add ``-Search`` option for ``Get-GraphChildItem`` to enable full-text search on Graph REST calls that support the OData ```$search`` query parameter
+* ``Set-GraphLocation`` now automounts a Graph specified as the beginning of a full path if it's not already mounted
+* ``Set-GraphLocation``: added the ``-NoAutoMount`` option to disable the newly added automount feature
 
 ## New dependencies
 
-* PoshGraph-SDK 0.3.0
+No new dependencies
 
 ## Fixed defects
 
-* See release notes for ``PoshGraph-SDK 0.3.0`` for fixes in that module that affected ``PoshGraph``
 "@
     } # End of PSData hashtable
 

--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -79,6 +79,7 @@ FunctionsToExport = @()
         'Get-Graph',
         'Get-GraphChildItem',
         'Get-GraphLocation',
+        'Get-GraphType',
         'Get-GraphUri',
         'New-Graph',
         'Remove-Graph',

--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -114,6 +114,7 @@ AliasesToExport = @('gcd', 'gg', 'ggu', 'gls', 'gwd')
         '.\src\cmdlets\Get-Graph.ps1',
         '.\src\cmdlets\Get-GraphChildItem.ps1',
         '.\src\cmdlets\Get-GraphLocation.ps1',
+        '.\src\cmdlets\Get-GraphType.ps1',
         '.\src\cmdlets\Get-GraphUri.ps1',
         '.\src\cmdlets\New-Graph.ps1',
         '.\src\cmdlets\Remove-Graph.ps1',
@@ -175,10 +176,11 @@ PrivateData = @{
 
 * ``Set-GraphLocation`` now automounts a Graph specified as the beginning of a full path if it's not already mounted
 * ``Set-GraphLocation``: added the ``-NoAutoMount`` option to disable the newly added automount feature
+* ``Get-GraphType``: new cmdlet to retrieve basic information about an entity type or complex type
 
 ## New dependencies
 
-No new dependencies
+No new dependencies.
 
 ## Fixed defects
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,12 +2,16 @@
 
 ## To-do items -- prioritized
 
-* Add app creation
-* Add app enumeration
-* Add app updating
+* Add app creation, enumeration, update
+  * New-GraphApplication
+  * Remove-GraphApplication
+  * Set-GraphApplication
+  * Set-GraphApplicationPermissions
+  * Remove-GraphApplicationConsent
 * Release
 
-* Add auto-mount to set-graphlocation
+* EntityAccess
+  * Ability to create Graph JSON
 
 * Clean up parse methods in GraphUtilities
 * Investigate console.writeline background thread
@@ -19,7 +23,6 @@
 * Release
 
 * Clean up utilities, special-case, duplicate code in get-graphuri, invoke-graphrequest, get-graphitem, get-graphchilditem
-* Make gcd work without hanging for new graphs
 
 * Investigate metadata perf optimization -- perform:
   * Discover roots only
@@ -231,6 +234,9 @@
 * Refactor into posh-graph core sdk and poshgraph ux
 * Add auto-complete for ggu
 * Add auto-complete for gls
+* Add auto-mount to set-graphlocation
+* Make gcd work without hanging for new graphs
+* Get-GraphType
 
 ### Postponed
 

--- a/autographps.psm1
+++ b/autographps.psm1
@@ -16,6 +16,7 @@ $cmdlets = @(
     'Get-Graph',
     'Get-GraphChildItem',
     'Get-GraphLocation',
+    'Get-GraphType',
     'Get-GraphUri',
     'New-Graph',
     'Remove-Graph',

--- a/autographps.tests.ps1
+++ b/autographps.tests.ps1
@@ -45,6 +45,7 @@ Describe "Autographps application" {
                 'Remove-Graph',
                 'Set-GraphLocation',
                 'Set-GraphPrompt',
+                'Get-GraphType',
                 'get-graphuri')
 
 

--- a/src/cmdlets.ps1
+++ b/src/cmdlets.ps1
@@ -17,6 +17,7 @@
 . (import-script cmdlets\Get-Graph)
 . (import-script cmdlets\Get-GraphChildItem)
 . (import-script cmdlets\Get-GraphLocation)
+. (import-script cmdlets\Get-GraphType)
 . (import-script cmdlets\Get-GraphUri)
 . (import-script cmdlets\New-Graph)
 . (import-script cmdlets\Remove-Graph)

--- a/src/cmdlets/Get-GraphType.ps1
+++ b/src/cmdlets/Get-GraphType.ps1
@@ -1,0 +1,65 @@
+# Copyright 2018, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. (import-script ../metadata/GraphManager)
+
+function Get-GraphType {
+    [cmdletbinding(positionalbinding=$false)]
+    param(
+        [parameter(position=0)]
+        $Name = $null,
+        $Graph = $null,
+        [Switch] $ComplexType
+    )
+
+    $context = if ( $Graph ) {
+        $::.Logicalgraphmanager.Get().contexts[$Graph].context
+    } else {
+        $::.GraphContext |=> GetCurrent
+    }
+
+    if ( ! $context ) {
+        throw "Unable to find specified context '$Graph'"
+    }
+
+    $entityGraph = $::.GraphManager |=> GetGraph $context
+
+    if ( ! $ComplexType.IsPresent ) {
+        $types = if ( $Name ) {
+            $qualifiedName = $::.Entity |=> QualifyName $entityGraph.namespace $Name
+            $entityGraph |=> TypeVertexFromTypename $qualifiedName
+        } else {
+            $entityGraph.typeVertices.values
+        }
+
+        if ( ! $types ) {
+            throw "Graph entity type '$Name' was not found in Graph '$($context.name)'"
+        }
+        if ( $Name ) {
+            $entityGraph.schema.Edmx.DataServices.schema.EntityType | where Name -eq $types.entity.name
+        } else {
+            $entityGraph.schema.Edmx.DataServices.schema.EntityType
+        }
+    } else {
+        if ( $Name ) {
+            $result = $entityGraph.schema.Edmx.DataServices.schema.ComplexType | where Name -eq $Name
+            if ( ! $result ) {
+                throw "Graph complex type '$Name' was not found in Graph '$($context.name)'"
+            }
+            $result
+        } else {
+            $entityGraph.schema.Edmx.DataServices.schema.ComplexType
+        }
+    }
+}

--- a/src/metadata/EntityGraph.ps1
+++ b/src/metadata/EntityGraph.ps1
@@ -23,14 +23,20 @@ ScriptClass EntityGraph {
     $rootVertices = $null
     $typeVertices = $null
     $namespace = $null
+    $schema = $null
 
-    function __initialize( $namespace, $apiVersion = 'localtest', [Uri] $endpoint = 'http://localhost' ) {
+    function __initialize( $namespace, $apiVersion = 'localtest', [Uri] $endpoint = 'http://localhost', $schemadata ) {
         $this.vertices = @{}
         $this.rootVertices = @{}
         $this.typeVertices = @{}
         $this.ApiVersion = $apiVersion
         $this.Endpoint = $endpoint
         $this.namespace = $namespace
+        $this.schema = $schemadata
+    }
+
+    function GetSchema {
+        $this.schema
     }
 
     function GetRootVertices {

--- a/src/metadata/GraphBuilder.ps1
+++ b/src/metadata/GraphBuilder.ps1
@@ -37,7 +37,7 @@ ScriptClass GraphBuilder {
     }
 
     function NewGraph {
-        $graph = new-so EntityGraph $this.namespace $this.version $this.graphEndpoint
+        $graph = new-so EntityGraph $this.namespace $this.version $this.graphEndpoint $this.dataModel.SchemaData
 
         __UpdateProgress 0
 
@@ -71,7 +71,6 @@ ScriptClass GraphBuilder {
         $progressIndex = 0
 
         $schemas | foreach {
-            $::.ProgressWriter |=> WriteProgress -id 2 -activity "Adding $($_.localname) vertices" -Status "In progress" -PercentComplete (100 * ($progressIndex / $progressTotal)) -currentoperation "Adding $($_.name)"
             __AddVertex $graph $_
             $progressIndex += 1
         }
@@ -96,7 +95,6 @@ ScriptClass GraphBuilder {
 
         $types | foreach {
             $source = $_
-            $::.ProgressWriter |=> WriteProgress -id 2 -activity "Adding entity type navigations" -currentoperation "Processing entity $($source.name)" -percentcomplete (100 * ( $progressIndex / $progressTotal ))
             $transitions = if ( $source.entity.navigations ) {
                 $source.entity.navigations
             } else {


### PR DESCRIPTION
### Description

The `Set-GraphLocation` cmdlet can now mount a graph by assuming that if a graph named with the optional graph name element preceding the root of an absolute path cannot be found that it might be interpreted as an API version on the current graph endpoint.
Added the new `Get-GraphType` cmdlet which gets the definition of an entity type or complex type from the Graph Schema.

### Implementation notes

The changes to automount via `Set-GraphLocation` simply parse the path in all cases, and if a Graph is found, it gets mounted using `GraphManager`.
`Get-GraphType` was implemented by adding the deserialized XML CSDL schema of the Graph to the `EntityGraph` type constructed in the background job by `GraphBuilder`. Then `Get-GraphType` could use this schema to search for the appropriate type.

### Checklist
- [x] All project tests pass successfully
