### PR TITLE
Verify auto-mounted Graph versions in Set-GraphLocation

### DIFF
--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -67,7 +67,7 @@ ScriptsToProcess = @('./src/graph.ps1')
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='autographps-sdk';ModuleVersion='0.4.1';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='autographps-sdk';ModuleVersion='0.5.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
     @{ModuleName='scriptclass';ModuleVersion='0.13.7';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
 )
 
@@ -171,19 +171,19 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @"
-# AutoGraphPS 0.15.0 Release Notes
+# AutoGraphPS 0.15.1 Release Notes
 
 ## New Features
 
-* ``Set-GraphLocation`` now automounts a Graph specified as the beginning of a full path if it's not already mounted
-* ``Set-GraphLocation``: added the ``-NoAutoMount`` option to disable the newly added automount feature
-* ``Get-GraphType``: new cmdlet to retrieve basic information about an entity type or complex type
+None.
 
 ## New dependencies
 
-No new dependencies.
+Update to ``autographps-sdk`` version ``0.5.0``.
 
 ## Fixed defects
+
+* The auto-mount feature of ``set-graphlocation`` now verifies that the API version you're trying to mount is actually provided by the Graph endpoint (i.e. it reaches out to the Graph endpoint and makes a trivial request to that API version to see if it exists). Previously you could auto-mount something that did not exist at all and it would appear to succeed -- this led to confusion later along with useless attempts by ``autographps`` to retry mounting that version in the background.
 
 "@
     } # End of PSData hashtable

--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.15.0'
+ModuleVersion = '0.15.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -67,7 +67,7 @@ ScriptsToProcess = @('./src/graph.ps1')
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='autographps-sdk';ModuleVersion='0.4.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='autographps-sdk';ModuleVersion='0.4.1';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
     @{ModuleName='scriptclass';ModuleVersion='0.13.7';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
 )
 

--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -183,6 +183,7 @@ Update to ``autographps-sdk`` version ``0.5.0``.
 
 ## Fixed defects
 
+* Fix parsing of ':' in paths passed to ``Get-GraphChildItem`` to correctly distinguish between graph names vs valid components of a URI
 * The auto-mount feature of ``set-graphlocation`` now verifies that the API version you're trying to mount is actually provided by the Graph endpoint (i.e. it reaches out to the Graph endpoint and makes a trivial request to that API version to see if it exists). Previously you could auto-mount something that did not exist at all and it would appear to succeed -- this led to confusion later along with useless attempts by ``autographps`` to retry mounting that version in the background.
 
 "@

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Note that since AutoGraphPS is built on [AutoGraphPS-SDK](https://github.com/ada
 | Get-GraphLocation         | gwd   | Retrieves the current location in the Uri hierarchy for the current graph                       |
 | Get-GraphSchema           |       | Returns the [Entity Data Model](https://docs.microsoft.com/en-us/dotnet/framework/data/adonet/entity-data-model) for a part of the graph as expressed through [CSDL](http://www.odata.org/documentation/odata-version-3-0/common-schema-definition-language-csdl/)       |
 | Get-GraphToken            |       | Gets an access token for the Graph -- helpful in using other tools such as [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer)  |
+| Get-GraphType             |       | Gets metadata for the specified resource type as documented in the [Graph reference](https://developer.microsoft.com/en-us/graph/docs/concepts/v1-overview)         |
 | Get-GraphUri              | ggu   | Gets detailed metadata about the segments of a Graph Uri or child segments of the Uri           |
 | Get-GraphVersion          |       | Returns the set of workloads and their associated schemas for a given Graph API version         |
 | Invoke-GraphRequest       |       | Executes a REST method (e.g. `GET`, `PUT`, `POST`, `DELETE`, etc.) for a Graph Uri           |

--- a/README.md
+++ b/README.md
@@ -99,16 +99,16 @@ Now traverse the Graph via the `gcd` alias to "move" to a new Uri current locati
 
 ```
 gcd me
-[starchild@mothership.io] v1.0:/me
+[starchild@mothership.io] /v1.0:/me
 PS>
 ```
 
-Notice the update to your prompt showing your authenticated identity and your new current location after invoking that last cmdlet: `[starchild@mothership.io] v1.0:/me`. **Tip:** the `gwd` alias acts like `pwd` in the file system and retrieve your current working location in the Graph.
+Notice the update to your prompt showing your authenticated identity and your new current location after invoking that last cmdlet: `[starchild@mothership.io] /v1.0:/me`. **Tip:** the `gwd` alias acts like `pwd` in the file system and retrieve your current working location in the Graph.
 
 Now you can use the `gls` alias as you would `ls` in the file system relative to your current location. Here's how you can read your email:
 
 ```
-[starchild@mothership.io] v1.0:/me
+[starchild@mothership.io] /v1.0:/me
 PS> gls messages
 ```
 
@@ -130,9 +130,9 @@ gls /
 
 Finally, here's one to enumerate your OneDrive files
 ```
-[starchild@mothership.io] v1.0:/me
+[starchild@mothership.io] /v1.0:/me
 PS> gcd drive/root/children
-[starchild@mothership.io] v1.0:/me/drive/root/children
+[starchild@mothership.io] /v1.0:/me/drive/root/children
 PS> gls
 
 Info Type      Preview       Name
@@ -151,8 +151,8 @@ Here are a few simple tips to keep in mind as you first start using AutoGraphPS:
 **3. You can access the Beta version of the Graph API**: By default, AutoGraphPS is targeted at the default API version of Graph, `v1.0`. It also works with the `beta` version -- just use the following commands to "mount" the `beta` version and set the current location to its root:
 
 ```powershell
-new-graph beta
-gcd beta:/ # This may take some time, you can CTRL-C and try again a few minutes later when its ready
+# You could also issue the command 'new-graph beta' to mount beta explicitly
+gcd /beta:/ # This sets the current location and implicitly mounts the 'beta' API version
 ```
 
 And that brings us to this **Warning**: *AutoGraphPS takes some time to get fully ready for each API version.* When you first execute commands like `gls` and `gcd`,, some information about the structure of the Graph may be incomplete. In these cases you should see a "warning" message. You can also Use the `gg` alias to see the status of your mounted API versions, i.e. `Ready`, `Pending`, etc., which can take a few minutes to reach the desired `Ready` state. Eventually the warning will no longer occur and the cmdlets will return full information after the background metadata processing completes.

--- a/autographps.nuspec
+++ b/autographps.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2018</copyright>
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
-      <dependency id="autographps-sdk" version="0.4.0" />
+      <dependency id="autographps-sdk" version="0.4.1" />
     </dependencies>
   </metadata>
   <files>

--- a/autographps.nuspec
+++ b/autographps.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2018</copyright>
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
-      <dependency id="autographps-sdk" version="0.4.1" />
+      <dependency id="autographps-sdk" version="0.5.0" />
     </dependencies>
   </metadata>
   <files>

--- a/docs/WALKTHROUGH.md
+++ b/docs/WALKTHROUGH.md
@@ -150,7 +150,7 @@ This makes `Get-GraphChildItem` an effective way to recursively discover the Uri
 You may have noticed that after the first time you invoked `Get-GraphChildItem`, your PowerShell prompt displayed some additional information:
 
 ```
-[starchild@mothership.io] v1.0:/
+[starchild@mothership.io] /v1.0:/
 PS>
 ```
 
@@ -160,7 +160,7 @@ With AutoGraphPS, you can traverse the Graph using `gls` and `gcd` just the way 
 
 ```
 gcd me/drive/root/children
-[starchild@mothership.io] v1.0:/me/drive/root/children
+[starchild@mothership.io] /v1.0:/me/drive/root/children
 PS> gls
 
 Info Type      Preview       Name
@@ -175,9 +175,9 @@ If you'd like to know what's "inside" of Recipes, you can `gcd` and `gls` again:
 
 ```
 
-[starchild@mothership.io] v1.0:/me/drive/root/children
+[starchild@mothership.io] /v1.0:/me/drive/root/children
 PS> gcd me/drive/root/children/Recipes
-[starchild@mothership.io] v1.0:/me/drive/root/children/Recipes
+[starchild@mothership.io] /v1.0:/me/drive/root/children/Recipes
 PS> gls
 
 Info Type             Preview    Name
@@ -190,7 +190,7 @@ n* > thumbnailSet                thumbnails
 n* > driveItemVersion            versions
 n  > workbook                    workbook
 
-[starchild@mothership.io] v1.0:/me/drive/root/children/Recipes
+[starchild@mothership.io] /v1.0:/me/drive/root/children/Recipes
 PS> gls
 
 Info Type      Preview           Name
@@ -198,7 +198,7 @@ Info Type      Preview           Name
 t +> driveItem SweetPotatePie.md 13K559
 t +> driveItem Gumbo.md          13K299
 
-[starchild@mothership.io] v1.0:/me/drive/root/children/Recipes
+[starchild@mothership.io] /v1.0:/me/drive/root/children/Recipes
 PS> gls
 ```
 
@@ -217,7 +217,7 @@ gwd
 
 Path
 ----
-v1.0:/me/drive/root/children/candidates/children
+/v1.0:/me/drive/root/children/candidates/children
 ```
 
 ## Query capabilities
@@ -496,7 +496,7 @@ Name         : root
 Namespace    : microsoft.graph
 Uri          : https://graph.microsoft.com/v1.0/me/drive/root
 GraphUri     : /me/drive/root
-Path         : v1.0:/me/drive/root
+Path         : /v1.0:/me/drive/root
 FullTypeName : microsoft.graph.driveItem
 Version      : v1.0
 Endpoint     : https://graph.microsoft.com/
@@ -602,7 +602,7 @@ Name         : myfile.txt
 Namespace    : microsoft.graph
 Uri          : https://graph.microsoft.com/v1.0/me/drive/root/children/myfile.txt
 GraphUri     : /me/drive/root/children/myfile.txt
-Path         : v1.0:/me/drive/root/children/myfile.txt
+Path         : /v1.0:/me/drive/root/children/myfile.txt
 FullTypeName : microsoft.graph.driveItem
 Version      : v1.0
 Endpoint     : https://graph.microsoft.com/

--- a/src/cmdlets/Get-GraphChildItem.ps1
+++ b/src/cmdlets/Get-GraphChildItem.ps1
@@ -94,13 +94,13 @@ function Get-GraphChildItem {
     }
 
     if ( ! $context ) {
-        $components = $resolvedUri.Path -split ':'
-
-        if ( $components.length -gt 2) {
+        $parsedPath = $::.GraphUtilities |=> ParseLocationUriPath $resolvedUri.Path
+        $context = if ( $parsedPath.ContextName ) {
+            $::.logicalgraphmanager.Get().contexts[$parsedPath.ContextName].context
+        }
+        if ( ! $context ) {
             throw "'$($resolvedUri.Path)' is not a valid graph location uri"
         }
-
-        $context = $::.logicalgraphmanager.Get().contexts[$components[0]].context
     }
 
     $results = @()

--- a/src/cmdlets/Set-GraphLocation.ps1
+++ b/src/cmdlets/Set-GraphLocation.ps1
@@ -47,7 +47,7 @@ function Set-GraphLocation {
             $pathContext = try {
                 write-verbose "Graph name '$($ParsedPath.ContextName)' was specified but no such graph is mounted"
                 write-verbose "Attempting to auto-mount Graph version '$($ParsedPath.ContextName)' using the existing connection"
-                $::.LogicalGraphManager |=> Get |=> NewContext $null $currentContext.connection $ParsedPath.ContextName $ParsedPath.ContextName
+                $::.LogicalGraphManager |=> Get |=> NewContext $null $currentContext.connection $ParsedPath.ContextName $ParsedPath.ContextName $true
             } catch {
                 write-verbose "Auto-mount attempt failed with error '$($_.exception.message)'"
             }

--- a/src/cmdlets/Set-GraphPrompt.ps1
+++ b/src/cmdlets/Set-GraphPrompt.ps1
@@ -62,7 +62,7 @@ $__GraphDefaultPrompt = {
 
         $promptOutput += $versionOutput
         $connectionOutput = '[{0}] ' -f ($promptOutput -join ', ')
-        $locationOutput = "{0}:{1}" -f $graph.name, $graph.currentlocation.graphuri
+        $locationOutput = "/{0}:{1}" -f $graph.name, $graph.currentlocation.graphuri
         $connectionStatus = if ( $graph.ConnectionStatus.tostring() -ne 'Online' ) { "({0}) " -f $graph.ConnectionStatus }
     }
 

--- a/src/cmdlets/common/LocationHelper.ps1
+++ b/src/cmdlets/common/LocationHelper.ps1
@@ -33,7 +33,7 @@ ScriptClass LocationHelper {
 
         function ToLocationUriPath( $context, $relativeUri ) {
             $graphRelativeUri = $this.ToGraphRelativeUriPathQualified($relativeUri, $context)
-            "{0}:{1}" -f $context.name, $graphRelativeUri
+            "/{0}:{1}" -f $context.name, $graphRelativeUri
         }
 
         function ToGraphRelativeUriPathQualified( $relativeUri, $context = $null ) {


### PR DESCRIPTION
### Description

* Fix parsing of ':' in paths passed to ``Get-GraphChildItem`` to correctly distinguish between graph names vs valid components of a URI
* The auto-mount feature of `set-graphlocation` now verifies that the API version you're trying to mount is actually provided by the Graph endpoint (i.e. it reaches out to the Graph endpoint and makes a trivial request to that API version to see if it exists). Previously you could auto-mount something that did not exist at all and it would appear to succeed -- this led to confusion later along with useless attempts by `autographps` to retry mounting that version in the background.

### Dependency changes

Update to `autographps-sdk` version `0.5.0`.

### Implementation notes

The updated `autographps-sdk` dependency exposes the ability to optionally check for the existence of the version specified for a new Graph through `LogicalGraphManager`. When `autographps` attempts to mount a potential version inferred from `set-graphlocation`, the version check is enabled. If the Graph endpoint in use in the current context does not support that version according to `LogicalGraphManager`, the mount (and thus the invocation of `set-graphlocation`) fails.

### Checklist

- [x] All project tests pass successfully