### PR TITLE
Allow paths with `:` characters for Get-GraphChildItem et. al.

### DIFF
--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.18.1'
+ModuleVersion = '0.18.2'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -67,8 +67,8 @@ ScriptsToProcess = @('./src/graph.ps1')
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='autographps-sdk';ModuleVersion='0.6.1';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
-    @{ModuleName='scriptclass';ModuleVersion='0.14.1';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
+    @{ModuleName='autographps-sdk';ModuleVersion='0.6.2';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='scriptclass';ModuleVersion='0.14.2';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
 )
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
@@ -167,20 +167,20 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @"
-# AutoGraphPS 0.18.1 Release Notes
+# AutoGraphPS 0.18.2 Release Notes
 
-Minor update that improves unit testing by updating dependencies
+Minor update to fix uri parsing issue with ':'
 
 ## New Features
 
 ## New dependencies
 
-* ScriptClass 0.14.0
-* AutoGraphPS-SDK 0.6.1
+* ScriptClass 0.14.2
+* AutoGraphPS-SDK 0.6.2
 
 ## Fixed defects
 
-* Update to ScriptClass 0.14.1 to remove slow  'import-module / remove-module' sequence  before tests that use ScriptClass mock functionality
+* Update to AutoGraphPS-SDK for fix for parsing Graph URI's with containing the ':' character
 
 "@
     } # End of PSData hashtable

--- a/autographps.nuspec
+++ b/autographps.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2018</copyright>
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
-      <dependency id="autographps-sdk" version="0.6.1" />
+      <dependency id="autographps-sdk" version="0.6.2" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
### Description

Updates `ScriptClass` dependency to 0.14.2 to fix issue here `Get-GraphChildItem` and related cmdlets could not handle URIs with `:` characters -- such URIs are actually supported by Graph.

### Dependency changes

* ScriptClass 0.14.2

### Checklist

- [x] All project tests pass successfully
