### PR TITLE
Regression fix for New-GraphApplication app-only auth, ExactMatch fix for Find-GraphPermissions

### DIFF
--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.20.1'
+ModuleVersion = '0.21.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -67,8 +67,8 @@ ScriptsToProcess = @('./src/graph.ps1')
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='autographps-sdk';ModuleVersion='0.7.1';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
-    @{ModuleName='scriptclass';ModuleVersion='0.14.2';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
+    @{ModuleName='autographps-sdk';ModuleVersion='0.8.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='scriptclass';ModuleVersion='0.15.0';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
 )
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
@@ -170,19 +170,23 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @"
-# AutoGraphPS 0.20.1 Release Notes
+# AutoGraphPS 0.21.0 Release Notes
 
 ## New Features
 
-None.
+* From AutoGraphPS-SDK: New 'CertOutputDirectory` option for ``New-GraphApplication`` -- see release notes for AutoGraphPS-SDK 0.8.0.
 
 ## New dependencies
 
-None.
+ScriptClass 0.15.0
+AutographPS-SDK 0.8.0
 
 ## Fixed defects
 
+* Fixed regression in ``New-GraphApplication`` for creating app-only apps with the ``NoninteractiveAppOnlyAuth`` parameter -- see release notes for AutoGraphPS-SDK 0.8.0
 * Fixed ``Find-GraphPermissions -ExactMatch`` where only delegated permissions were returned for cases where there was also an app-only permission with the same name such as ``Group.Read.All``.
+
+
 
 "@
     } # End of PSData hashtable

--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -12,7 +12,7 @@
 # RootModule = ''
 
 # Version number of this module.
-ModuleVersion = '0.20.0'
+ModuleVersion = '0.20.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -170,21 +170,19 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @"
-# AutoGraphPS 0.20.0 Release Notes
-
-Update ``AutoGraphPS-SDK`` dependency to remove need for defect workarounds, get new ``Get-GraphToken`` improvements.
+# AutoGraphPS 0.20.1 Release Notes
 
 ## New Features
 
-* ``Get-GraphToken`` cmdlet takes more parameters for obtaining tokens, including app-only tokens and v1 protocol support.
+None.
 
 ## New dependencies
 
-* AutoGraphPS-SDK 0.7.1
+None.
 
 ## Fixed defects
 
-* Removed workaround for defect in AutoGraphPS-SDK ``ScopeHelper`` class that would return all permissions when only delegated permissions were requested from GetKnownPermissionsSorted
+* Fixed ``Find-GraphPermissions -ExactMatch`` where only delegated permissions were returned for cases where there was also an app-only permission with the same name such as ``Group.Read.All``.
 
 "@
     } # End of PSData hashtable

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,26 +2,12 @@
 
 ## To-do items -- prioritized
 
-* Get a fix from sdk for scope helper in find-graphpermissions
+
+* Preserve identity when mounting graphs
 * Fix qualified / vs. unqualified names in metadata classes
 * Add `$value` support.
 * Add enumeration type support to get-graphtype
 * Move app to new tenant (or create a new one)
-
-* Add app creation, enumeration, update
-  * New-GraphApplication
-  * Get-GraphApplication
-  * New-GraphApplicationCertificate
-  * Get-GraphApplicationCertificate
-  * Set-GraphApplicationCertificate
-  * Get-GraphApplicationLocalCertificate
-  * Remove-GraphApplicationLocalCertificate
-  * Import-GraphApplicationLocalCertificate
-  * Remove-GraphApplication
-  * Set-GraphApplication
-  * Set-GraphApplicationPermissions
-  * Remove-GraphApplicationConsent
-* Release
 
 * EntityAccess
   * Ability to create Graph JSON
@@ -261,6 +247,7 @@
   * Process singletons metadata in foreground
   * Use expressions like  ($::.GraphManager.cache.graphversions.values[0].schema[0].edmx.dataservices.schema.action).parameter |where name -eq bindParameter
   * Better: $bindings = ( ($::.GraphManager.cache.graphversions.values[0].schema[0].edmx.dataservices.schema.action)) | foreach { $method = $_.name; $_.parameter | where name -eq bindingParameter | foreach {[PSCustomObject]@{Type=$_.type;Method=$method}}}
+* Add app creation, enumeration, update
 
 ### Postponed
 
@@ -272,6 +259,7 @@
 * Add hint of additional records
 * Add continue feature?
 * Test Release
+* Get a fix from sdk for scope helper in find-graphpermissions
 
 ### Abandoned
 


### PR DESCRIPTION
### Dependency changes

* ScriptClass 0.15.0
* AutoGraphPS-SDK 0.8.0

### Implementation notes

* Fixed regression in ``New-GraphApplication`` for creating app-only apps with the ``NoninteractiveAppOnlyAuth`` parameter -- see release notes for AutoGraphPS-SDK 0.8.0
* Fixed ``Find-GraphPermissions -ExactMatch`` where only delegated permissions were returned for cases where there was also an app-only permission with the same name such as ``Group.Read.All``.

### Checklist
- [x] All project tests pass successfully
