### PR TITLE
Fixes and minor improvmeents via update to AutoGraphPS-SDK 0.12.0 dependency

### DIFF
--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.24.1'
+ModuleVersion = '0.25.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -67,7 +67,7 @@ PowerShellVersion = '5.1'
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='AutoGraphPS-SDK';ModuleVersion='0.11.2';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='AutoGraphPS-SDK';ModuleVersion='0.12.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
     @{ModuleName='scriptclass';ModuleVersion='0.20.1';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
 )
 
@@ -175,26 +175,45 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-# AutoGraphPS 0.24.1 Release Notes
+# AutoGraphPS 0.25.0 Release Notes
 
 This release is incorporates fixes for regressions introduced in the previous
 release by the inclusion `AutoGraphPS-SDK` `0.11.1` by updating that dependency
-to a new version.
+to a new version. It also includes minor features from that version.
 
-This release also includes release note o missions from the previous `0.24.0`
+This release also includes release note omissions from the previous `0.24.0`
 release.
 
 ## New dependencies
 
-AutoGraphPS-SDK 0.24.1
+* AutoGraphPS-SDK 0.12.0
+
+## Breaking changes
+None.
+
+## New features
+New features in this release originate from the updated `AutoGraphPS-SDK` dependency:
+
+* Added the `ReplyUrl` alias to the `AppRedirectUri` parameter of `Get-GraphToken`, `Connect-Graph` and `New-GraphConnection`
+* `Get-GraphConnectionInfo` now includes a connection id guid property in its output to identify each unique connection
+
+## Fixed defects
+The bug fixes in this release originate from the updated `AutoGraphPS-SDK` dependency:
+
+* `Test-Graph` command regression prevented targeting clouds other than `Public`
+* `Connect-Graph` and `New-GraphConnection` regressions caused certain parameter sets to require all parameters
+* Fix race condition with `Connect-Graph` due to MSAL changes with integrated token cache: `Connect-Graph` created
+  a new token, which was immediately invalidated, requiring a reconnect when used with a command.
+* Fix error output from `Get-GraphToken` due to invalid `$GraphEndpointUri` variable, which also prevented the `GraphResourceUri` parameter from functioning correctly.
 
 ## Addendum: omissions from 0.24.0 release notes
-
 These release notes were omitted from the previous release because they actually
 describe functionality originating in a dependency rather than this module. Nevertheless,
 that functionality is experienced by the user simply as part of this module, so
-they should have been included so that users could understand and assess the new behavior
+the notes should have been included so that users could understand and assess the new behavior
 including breaking changes.
+
+These notes are included below as a correction.
 
 ### Breaking changes
 
@@ -212,7 +231,7 @@ including breaking changes.
 * The `ConsentForTenant` flag had an ambiguous meaning and was replaced by `ConsentAllUsers` for
   application management and consent-related commands
 
-#### New features
+### New features
 
 * App-only consent: The code defect in the MS Graph REST API blocking app-only consent was addressed,
   so now `New-GraphApplication`, `Set-GraphApplicationConsent`, `Get-GraphApplicationConsent`,
@@ -227,7 +246,7 @@ including breaking changes.
   is used to get to Graph -- the resource URI for token acquisition can be set to `https://graph.microsoft.com`
   using the `GraphResourceUri` parameter, and the endpoint can be the proxy in front of Graph.
 
-#### Fixed defects
+### Fixed defects
 
 * Used `ErrorAction Ignore` instead of `SilentlyContinue` in numerous places throughout the code
   to avoid error stream pollution

--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.24.0'
+ModuleVersion = '0.24.1'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -67,7 +67,7 @@ PowerShellVersion = '5.1'
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='AutoGraphPS-SDK';ModuleVersion='0.11.1';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='AutoGraphPS-SDK';ModuleVersion='0.11.2';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
     @{ModuleName='scriptclass';ModuleVersion='0.20.1';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
 )
 
@@ -175,38 +175,63 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-# AutoGraphPS 0.24.0 Release Notes
+# AutoGraphPS 0.24.1 Release Notes
 
-This release addresses the breaking changes in the ScriptClass dependency. It also updates
-the Graph browsing experience through `gls` to be more like browsing a file system
-with the familiar `ls` command.
+This release is incorporates fixes for regressions introduced in the previous
+release by the inclusion `AutoGraphPS-SDK` `0.11.1` by updating that dependency
+to a new version.
 
-## Breaking changes
-
-* Objects returned by commands in this module will have a slightly different structure
-  due to the changes to ScriptClass
-* The `gls` alias now points to a new command, `Get-GraphItemWithMetadata` with a slightly
-  different set of parameters and a different default behavior for returning results
-
-## New Features
-
-* New `Get-GraphItemWithMetadata` command which has behavior similar to `Get-GraphChildItem`
-  but with differetn defaults.
-* The `gls` alias now tries to emulate the behavior of the `ls` alias in PowerShell that also
-  exist as a command in `bash` and other shells: when the target of `ls` is not a set, only
-  the target is output, not its children (though this cannot happen in traditional file system
-  context where `ls` is used) or content. Previously `gls` aliased `Get-GraphChildItem`, which
-  always returns the target AND children.
+This release also includes release note o missions from the previous `0.24.0`
+release.
 
 ## New dependencies
 
-AutoGraphPS-SDK 0.11.1
-ScriptClass 0.20.1
+AutoGraphPS-SDK 0.24.1
 
-## Fixed defects
+## Addendum: omissions from 0.24.0 release notes
 
-* Fixed numerous error stream pollution defects
+These release notes were omitted from the previous release because they actually
+describe functionality originating in a dependency rather than this module. Nevertheless,
+that functionality is experienced by the user simply as part of this module, so
+they should have been included so that users could understand and assess the new behavior
+including breaking changes.
 
+### Breaking changes
+
+* The `Connect-Graph`, `New-GraphConnection`, and `Get-GraphToken` commands now have the same parameter names where
+  the parameters represent the same thing.
+* Some command parameter names have been changed for clarity
+* The `GrantedPermissions` parameter has been replaced with two new parameters in several commands that
+  could take both app-only permissions and delegated permissions: `ApplicationPermisisons`
+  and `DelegatedUserPermissions`
+* The `Permissions` parameter in several commands auto-completed to both app-only and delegated
+  permissions, but since only delegated permissions can be specified at runtime for these
+  commands, auto-complete now only completes delegated permissions
+* The `NoninteractiveAppOnlyAuth` parameter of several commands is no longer necessary -- the presence of
+  `Confidential` and `ApplicationPermissions` parameters indicates the state this parameter represented
+* The `ConsentForTenant` flag had an ambiguous meaning and was replaced by `ConsentAllUsers` for
+  application management and consent-related commands
+
+#### New features
+
+* App-only consent: The code defect in the MS Graph REST API blocking app-only consent was addressed,
+  so now `New-GraphApplication`, `Set-GraphApplicationConsent`, `Get-GraphApplicationConsent`,
+  and `Remove-GraphApplicationConsent` have been updated to support it
+* In particular `New-GraphApplication` automatically consents confidential app-only apps because the
+  Graph API for doing so is now fixed. Therefore the command o longer displays a warning when creating
+  instructing the user to manually consent the app.
+* `Connect-Graph` now returns `GraphConnectionInfo` object
+* `Connect-Graph`, `New-GraphConnection`, and `Get-GraphToken` now support the new `GraphResourceUri`
+  parameter which allows the caller to use a resource URI that is not the same as the actual
+  graph endpoint used for REST. This is useful for test scenarios, such as those where a proxy
+  is used to get to Graph -- the resource URI for token acquisition can be set to `https://graph.microsoft.com`
+  using the `GraphResourceUri` parameter, and the endpoint can be the proxy in front of Graph.
+
+#### Fixed defects
+
+* Used `ErrorAction Ignore` instead of `SilentlyContinue` in numerous places throughout the code
+  to avoid error stream pollution
+* General error stream pollution cleanup
 '@
     } # End of PSData hashtable
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,6 @@ AutoGraphPS
 * [Quickstart](#quickstart)
 * [License and authors](#license-and-authors)
 
-*This repository / project  was recently renamed from **PoshGraph** -- if you're looking for **PoshGraph**, you're in the right place!*
-
 ## Overview
 
 **AutoGraphPS** is a PowerShell-based CLI for exploring the [Microsoft Graph](https://graph.microsoft.io/). It can be thought of as a CLI analog to the browser-based [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer). AutoGraphPS enables powerful command-line access to the Microsoft Graph REST API gateway. The Graph exposes a growing list of services such as
@@ -279,7 +277,7 @@ This should return something like the following:
     TimeLocal  : 2/6/2018 6:05:09 AM
     TimeUtc    : 2/6/2018 6:05:09 AM
 
-If you need to launch another console with Posh Graph, you can run the faster command below which skips the build step since QuickStart already did that for you (though it's ok to run QuickStart again):
+If you need to launch another console with AutoGraphPS, you can run the faster command below which skips the build step since QuickStart already did that for you (though it's ok to run QuickStart again):
 
     .\build\import-devmodule.ps1
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ AutoGraphPS
 
 If you're an application developer, DevOps engineer, system administrator, or enthusiast power user, AutoGraphPS was made just for you. If you're building Graph-based applications in PowerShell, consider using the lighter-weight [AutoGraphPS-SDK](https://github.com/adamedx/autographps-sdk) which contains a smaller kernel of Graph cmdlets focused on automation and omitting the UX affordances found in this module.
 
-The project is in the earliest stages of development and almost but not quite yet ready for collaborators.
+If you have ideas on how to improve **AutoGraphPS**, please consider [opening an issue](https://github.com/adamedx/autographps/issues) or a [pull request](https://github.com/adamedx/autographps/pulls).
 
 ### System requirements
 
@@ -246,7 +246,7 @@ cd autographps
 
 ## Contributing and development
 
-Read about our contribution process in [CONTRIBUTING.md](CONTRIBUTING.md). The project is not quite ready to handle source contributions; suggestions on features or other advice are welcome while we establish a baseline.
+Read about our contribution process in [CONTRIBUTING.md](CONTRIBUTING.md). In addition to submitting pull requests, we also invite bug reports, eature requests, and architectural improvements through this repository's [issues page](https://github.com/adamedx/autographps/issues).
 
 See the [Build README](build/README.md) for instructions on building and testing changes to AutoGraphPS.
 

--- a/autographps.nuspec
+++ b/autographps.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2019</copyright>
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
-      <dependency id="autographps-sdk" version="0.11.1" />
+      <dependency id="autographps-sdk" version="0.11.2" />
     </dependencies>
   </metadata>
   <files>

--- a/autographps.nuspec
+++ b/autographps.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2019</copyright>
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
-      <dependency id="autographps-sdk" version="0.11.2" />
+      <dependency id="autographps-sdk" version="0.12.0" />
     </dependencies>
   </metadata>
   <files>

--- a/build/welcome.ps1
+++ b/build/welcome.ps1
@@ -12,12 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-write-host -foregroundcolor cyan "`nWelcome to Posh Graph!`n"
+write-host -foregroundcolor cyan "`nWelcome to AutoGraphPS!`n"
 write-host "To get started, try executing any of the following commands:"
 @(
     [PSCustomObject]@{Command="    Test-Graph";Purpose="# Retrieves diagnostic information from a Microsoft Graph Service endpoint"}
     [PSCustomObject]@{Command="    Connect-Graph";Purpose="# Establishes a convenient connection context; no need to re-auth for each command"}
-    [PSCustomObject]@{Command="    Get-GraphItem me";Purpose="# Gets the user profile of the authenticated user"}
-    [PSCustomObject]@{Command="    Get-GraphVersion v1.0";Purpose="# Gets information about Graph API versions such as v1.0, beta, etc."}
+    [PSCustomObject]@{Command="    Get-GraphToken";Purpose="# Gets information about Graph API versions such as v1.0, beta, etc."}
+    [PSCustomObject]@{Command="    gls";Purpose="# Enumerates child uri graph segments of the current location."}
+    [PSCustomObject]@{Command="    gcd me";Purpose="# Changes the current location to the 'me' segment of the graph."}
+    [PSCustomObject]@{Command="    gwd";Purpose="# Output the current location."}
+    [PSCustomObject]@{Command="    gls";Purpose="# Enumerates the children of the (new) current location."}
+    [PSCustomObject]@{Command="    gls messages";Purpose="# Enumerates email messages ('me/messages')."}
+    [PSCustomObject]@{Command="    Get-GraphItem /organization";Purpose="# For AAD accounts, gets organization information using an absolute path"}
+    [PSCustomObject]@{Command="    Get-Graph";Purpose="# Outputs information about all the current graphs and their API versions"}
+    [PSCustomObject]@{Command="    gcd /beta:";Purpose="# Mount an entirely new graph of API version 'beta' and change the current location to it."}
+    [PSCustomObject]@{Command="    gls me";Purpose="# Enumerate the 'me' segment itself."}
+    [PSCustomObject]@{Command="    Get-Graph";Purpose="# Output the currently mounted graphs."}
 ) | format-table -wrap -hidetableheaders | out-host
 write-host ''


### PR DESCRIPTION
This release is incorporates fixes for regressions introduced in the previous
release by the inclusion `AutoGraphPS-SDK` `0.11.1` by updating that dependency
to a new version. It also includes minor features from that version.

This release also includes release note omissions from the previous `0.24.0`
release.

## New dependencies

* AutoGraphPS-SDK 0.12.0

## Breaking changes
None.

## New features
New features in this release originate from the updated `AutoGraphPS-SDK` dependency:

* Added the `ReplyUrl` alias to the `AppRedirectUri` parameter of `Get-GraphToken`, `Connect-Graph` and `New-GraphConnection`
* `Get-GraphConnectionInfo` now includes a connection id guid property in its output to identify each unique connection

## Fixed defects
The bug fixes in this release originate from the updated `AutoGraphPS-SDK` dependency:

* `Test-Graph` command regression prevented targeting clouds other than `Public`
* `Connect-Graph` and `New-GraphConnection` regressions caused certain parameter sets to require all parameters
* Fix race condition with `Connect-Graph` due to MSAL changes with integrated token cache: `Connect-Graph` created
  a new token, which was immediately invalidated, requiring a reconnect when used with a command.
* Fix error output from `Get-GraphToken` due to invalid `$GraphEndpointUri` variable, which also prevented the `GraphResourceUri` parameter from functioning correctly.

### Checklist

- [x] All project tests pass successfully
