### PR TITLE
Dependency update to AutoGraphPS-SDK 0.14.0, rename Find-GraphPermissions, preview fix

### DIFF
--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.26.0'
+ModuleVersion = '0.27.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -30,7 +30,7 @@ CompanyName = 'Modulus Group'
 Copyright = '(c) 2019 Adam Edwards.'
 
 # Description of the functionality provided by this module
-Description = 'CLI for automating the Microsoft Graph'
+Description = 'CLI for automating and exploring the Microsoft Graph'
 
 # Minimum version of the Windows PowerShell engine required by this module
 PowerShellVersion = '5.1'
@@ -67,13 +67,13 @@ PowerShellVersion = '5.1'
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='AutoGraphPS-SDK';ModuleVersion='0.13.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='AutoGraphPS-SDK';ModuleVersion='0.14.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
     @{ModuleName='scriptclass';ModuleVersion='0.20.1';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
 )
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(
-    'Find-GraphPermissions',
+    'Find-GraphPermission',
     'Get-Graph',
     'Get-GraphChildItem',
     'Get-GraphItemWithMetadata',
@@ -117,7 +117,7 @@ AliasesToExport = @('gcd', 'gg', 'ggu', 'ggci', 'gls', 'gwd')
         '.\src\cmdlets.ps1',
         '.\src\graph.ps1',
         '.\src\client\LocationContext.ps1',
-        '.\src\cmdlets\Find-GraphPermissions.ps1',
+        '.\src\cmdlets\Find-GraphPermission.ps1',
         '.\src\cmdlets\Get-Graph.ps1',
         '.\src\cmdlets\Get-GraphChildItem.ps1',
         '.\src\cmdlets\Get-GraphItemWithMetadata.ps1',
@@ -175,29 +175,36 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-## AutoGraphPS 0.26.0 Release Notes
+## AutoGraphPS 0.27.0 Release Notes
 
-This release updates the autographps-sdk dependency to 0.13.0 to obtain new features
-for specifying a client request id and to allow customization of the user agent. Defect fixes,
-particularly in the area of application and consent management, are also included.
+This release updates the autographps-sdk dependency to 0.14.0 to obtain new features
+for logging requests to Graph and their responses and viewing / formatting the logged
+data.
 
 ### New dependencies
 
-* AutoGraphPS-SDK 0.13.0
+* AutoGraphPS-SDK 0.14.0
 
 ### Breaking changes
-* For some commands originating in *AutoGraphPS-SDK*, certain parameters have been renamed.
-  See [AutoGraphPS-SDK 0.13.0 Release notes](https://www.powershellgallery.com/packages/autographps-sdk/0.13.0).
+* The Find-GraphPermissions command has been renamed to Find-GraphPermission to align with PowerShell
+  naming conventions around the use of singular nouns
 
 ### New features
 
-* `ClientRequestId` parameter for `Get-GraphChildItem` and `Get-GraphItemWithMetadata` to specify `client-request-id` header
-* See additional features from [AutoGraphPS-SDK 0.13.0 Release notes](https://www.powershellgallery.com/packages/autographps-sdk/0.13.0).
+* The `Preview` column of `Get-GraphItemWithMetadata` (`gls`) includes support for APIs like Teams chats
+  that show up under `me/messages` -- previously the preview was using the `id` column for such APIs
+  which was useless from a readability / user experience standpoint.
+
+The additional new features all originate from the AutoGraphPS-SDK 0.14.0 dependency:
+
+* The `Get-GraphLog` command enables retrieval of records of each request and response to the Graph
+* The `Format-GraphLog` command allows optimized formatting of Graph request logs from `Get-GraphLog`
+* The `Clear-GraphLog` command removes all previous log entries from the log
+* The `Set-GraphLogOption` command allows customization of the logging level and other logging behaviors
+* The `Get-GraphLogOption` command returns information about the current request logging configuration
 
 ### Fixed defects
-
-* Work around *ScriptClass* defect where verbose output is not enabled for code in *AutoGraphPS-SDK*.
-* See additional fixes [AutoGraphPS-SDK 0.13.0 Release notes](https://www.powershellgallery.com/packages/autographps-sdk/0.13.0).
+None.
 
 '@
     } # End of PSData hashtable

--- a/README.md
+++ b/README.md
@@ -179,10 +179,12 @@ Note that since AutoGraphPS is built on [AutoGraphPS-SDK](https://github.com/ada
 
 | Cmdlet (alias)            | Description                                                                                             |
 |---------------------------|---------------------------------------------------------------------------------------------------------|
+| Clear-GraphLog            | Clear the log of REST requests to Graph made by the module's commands                                   |
 | Connect-Graph             | Establishes authentication and authorization context used across cmdlets for the current graph          |
 | Disconnect-Graph          | Clears authentication and authorization context used across cmdlets for the current graph               |
 | Find-GraphPermissions     | Given a search string, `Find-GraphPermissions` lists permissions with names that contain that string    |
 | Find-GraphLocalCertificate  | Gets a list of local certificates created by AutoGraphPS-SDK to for app-only or confidential delegated auth to Graph |
+| Format-GraphLog           | Emits the Graph request log to the console in a manner optimized for understanding Graph and troubleshooting requests |
 | Get-Graph (gg)            | Gets the current list of versioned Graph service endpoints available to AtuoGraphPS                     |
 | Get-GraphChildItem (gls)  | Retrieves in tabular format the list of entities for a given Uri AND child segments of the Uri          |
 | Get-GraphApplication              | Gets a list of Azure AD applications in the tenant                                              |
@@ -194,6 +196,8 @@ Note that since AutoGraphPS is built on [AutoGraphPS-SDK](https://github.com/ada
 | Get-GraphItem (ggi)       | Given a relative (to the Graph or current location) Uri gets information about the entity               |
 | Get-GraphItemWithMetadata (gls) | Retrieves in tabular format the list of entities and metadata for a given Uri                     |
 | Get-GraphLocation (gwd)   | Retrieves the current location in the Uri hierarchy for the current graph                               |
+| Get-GraphLog              | Gets the local log of all requests to Graph made by this module                                         |
+| Get-GraphLogOption        | Gets the configuration options for logging of requests to Graph including options that control the detail level of the data logged |
 | Get-GraphToken            | Gets an access token for the Graph -- helpful in using other tools such as [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer)  |
 | Get-GraphType             | Gets metadata for the specified resource type as documented in the [Graph reference](https://developer.microsoft.com/en-us/graph/docs/concepts/v1-overview)         |
 | Get-GraphUri (ggu)        | Gets detailed metadata about the segments of a Graph Uri or child segments of the Uri                   |
@@ -211,6 +215,7 @@ Note that since AutoGraphPS is built on [AutoGraphPS-SDK](https://github.com/ada
 | Set-GraphApplicationConsent       | Sets a consent grant for an Azure AD application                                                |
 | Set-GraphConnectionStatus | Configures `Offline` mode for use with local commands like `GetGraphUri` or re-enables `Online` mode for accessing the Graph service |
 | Set-GraphLocation (gcd)   | Sets the current graph and location in the graph's Uri hierarchy; analog to `cd` / `set-location` cmdlet for PowerShell when working with file systems |
+| Set-GraphLogOption        | Sets the configuration options for logging of requests to Graph including options that control the detail level of the data logged |
 | Set-GraphPrompt           | Adds connection and location context to the PowerShell prompt or disables it                            |
 | Show-GraphHelp            | Given the name of a Graph resource (e.g. 'user', 'group', etc.) launches a web browser focused on documentation for it |
 | Test-Graph                | Retrieves unauthenticated diagnostic information from instances of your Graph endpoint                  |

--- a/autographps.nuspec
+++ b/autographps.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2019</copyright>
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
-      <dependency id="autographps-sdk" version="0.12.0" />
+      <dependency id="autographps-sdk" version="0.14.0" />
     </dependencies>
   </metadata>
   <files>

--- a/autographps.psm1
+++ b/autographps.psm1
@@ -15,7 +15,7 @@
 . (join-path $psscriptroot src/graph.ps1)
 
 $functions = @(
-    'Find-GraphPermissions',
+    'Find-GraphPermission',
     'Get-Graph',
     'Get-GraphChildItem',
     'Get-GraphItemWithMetadata',

--- a/autographps.tests.ps1
+++ b/autographps.tests.ps1
@@ -31,7 +31,7 @@ Describe "Autographps application" {
     Context "When loading the manifest" {
         It "should export the exact same set of functions as are in the set of expected functions" {
             $expectedFunctions = @(
-                'Find-GraphPermissions',
+                'Find-GraphPermission',
                 'update-graphmetadata',
                 'Get-Graph',
                 'Get-GraphChildItem',

--- a/src/cmdlets.ps1
+++ b/src/cmdlets.ps1
@@ -14,7 +14,7 @@
 
 . (import-script client/LocationContext)
 
-. (import-script cmdlets\Find-GraphPermissions)
+. (import-script cmdlets\Find-GraphPermission)
 . (import-script cmdlets\Get-Graph)
 . (import-script cmdlets\Get-GraphItemWithMetadata)
 . (import-script cmdlets\Get-GraphChildItem)

--- a/src/cmdlets/Find-GraphPermission.ps1
+++ b/src/cmdlets/Find-GraphPermission.ps1
@@ -14,7 +14,7 @@
 
 . (import-script common/PermissionHelper)
 
-function Find-GraphPermissions {
+function Find-GraphPermission {
     [cmdletbinding(positionalbinding=$false, defaultparametersetname='allpermissions')]
     param(
         [parameter(position=0, parametersetname='searchspec')]
@@ -73,4 +73,4 @@ function Find-GraphPermissions {
     }
 }
 
-$::.ParameterCompleter |=> RegisterParameterCompleter Find-GraphPermissions Permission (new-so PermissionParameterCompleter DelegatedPermission)
+$::.ParameterCompleter |=> RegisterParameterCompleter Find-GraphPermission Permission (new-so PermissionParameterCompleter DelegatedPermission)

--- a/src/cmdlets/common/SegmentHelper.ps1
+++ b/src/cmdlets/common/SegmentHelper.ps1
@@ -179,7 +179,7 @@ ScriptClass SegmentHelper {
         }
 
         function __GetPreview($content, $defaultValue) {
-            $previewProperties = $content | select Name, DisplayName, Title, FileName, Subject, Id
+            $previewProperties = $content | select Name, DisplayName, Title, FileName, Subject, Id, bodyPreview
             if ( $previewProperties.Name ) {
                 $previewProperties.Name
             } elseif ( $previewProperties.DisplayName ) {
@@ -190,6 +190,8 @@ ScriptClass SegmentHelper {
                 $previewProperties.FileName
             } elseif ( $previewProperties.Subject ) {
                 $previewProperties.Subject
+            } elseif ( $previewProperties.bodyPreview ) {
+                $previewproperties.bodyPreview
             } elseif ( $previewProperties.Id ) {
                 $previewProperties.Id
             } else {


### PR DESCRIPTION
### Description

This release updates the autographps-sdk dependency to 0.14.0 to obtain new features
for logging requests to Graph and their responses and viewing / formatting the logged
data.

### New dependencies

* AutoGraphPS-SDK 0.14.0

### Breaking changes
* The Find-GraphPermissions command has been renamed to Find-GraphPermission to align with PowerShell
  naming conventions around the use of singular nouns

### New features

* The `Preview` column of `Get-GraphItemWithMetadata` (`gls`) includes support for APIs like Teams chats
  that show up under `me/messages` -- previously the preview was using the `id` column for such APIs
  which was useless from a readability / user experience standpoint.

The additional new features all originate from the AutoGraphPS-SDK 0.14.0 dependency:

* The `Get-GraphLog` command enables retrieval of records of each request and response to the Graph
* The `Format-GraphLog` command allows optimized formatting of Graph request logs from `Get-GraphLog`
* The `Clear-GraphLog` command removes all previous log entries from the log
* The `Set-GraphLogOption` command allows customization of the logging level and other logging behaviors
* The `Get-GraphLogOption` command returns information about the current request logging configuration

### Fixed defects
None.

### Checklist

- [x] All project tests pass successfully
