### PR TITLE
Parameter completion for external Graph commands, AutoGraphPS-SDK 0.16.0 bug fixes

### DIFF
--- a/AutoGraphPS.psd1
+++ b/AutoGraphPS.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.28.0'
+ModuleVersion = '0.29.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -67,7 +67,7 @@ PowerShellVersion = '5.1'
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='AutoGraphPS-SDK';ModuleVersion='0.15.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='AutoGraphPS-SDK';ModuleVersion='0.16.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
     @{ModuleName='scriptclass';ModuleVersion='0.20.1';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
 )
 
@@ -164,7 +164,7 @@ PrivateData = @{
         LicenseUri = 'http://www.apache.org/licenses/LICENSE-2.0'
 
         # A URL to the main website for this project.
-        ProjectUri = 'https://github.com/adamedx/poshgraph'
+        ProjectUri = 'https://github.com/adamedx/autographps'
 
         # A URL to an icon representing this module.
         IconUri = 'https://raw.githubusercontent.com/adamedx/poshgraph/master/assets/PoshGraphIcon.png'
@@ -175,33 +175,34 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-## AutoGraphPS 0.28.0 Release Notes
+## AutoGraphPS 0.29.0 Release Notes
 
-This release updates the autographps-sdk dependency to 0.15.0 to obtain fixes and
+This release updates the autographps-sdk dependency to 0.16.0 to obtain fixes and
 minor improvements.
 
 ### New dependencies
 
-* AutoGraphPS-SDK 0.15.0
+* AutoGraphPS-SDK 0.16.0
 
 ### Breaking changes
 None.
 
 ### New features
 
-The new features all originate from the AutoGraphPS-SDK 0.14.0 dependency:
+* URI parameter completion is enabled for the following commands exposed by AutoGraphPS-SDK: `Get-GraphItem`, `Invoke-GraphRequest`.
 
-* The `ggl` alias for `Get-GraphLog` has been added
-* The `fgl` alias for `Format-GraphLog` has also been added
+The following new features originate from the AutoGraphPS-SDK 0.16.0 dependency:
+
+* The `Get-GraphLog` command has a new `StatusFilter` parameter that specifies that the command must return only log etnries with an error status, only those with a success status, or any status (the default).
 
 ### Fixed defects
 
-See the release notes for AutoGraphPS-SDK 0.15.0 which inclues these fixes:
+* Fixed missing uri parameter completion for Get-GraphChildItem
+* Commands such as `New-GraphApplication` from AutoGraphPS-SDK failed if the current graph location set by `Set-GraphLocation` was no the root (default) -- this is fixed so that commands for managing applications such as `New-GraphApplication` are no longer influenced by the current graph location.
 
-* `Format-GraphLog` specified the 'Wrap' parameter as a string rather than as switch -- the parameter was unusable
-* `Format-GraphLog`: `Authentication` value for `View` parameter broken due to invalid property
-* `Permissions` column from `Get-GraphLog` only included requested permissions, not actual token permissions -- fixed
-  to reflect the latter
+Also, see the release notes for AutoGraphPS-SDK 0.16.0 which inclues these fixes:
+
+* Application management commands such as `New-GraphApplication` would fail due to a bad URI when used by a module like *AutoGraphPS* that allows the default base URI to be changed -- fixed so that URIs used by the application management commands are context invariant.
 
 '@
     } # End of PSData hashtable

--- a/autographps.nuspec
+++ b/autographps.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2019</copyright>
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
-      <dependency id="autographps-sdk" version="0.15.0" />
+      <dependency id="autographps-sdk" version="0.16.0" />
     </dependencies>
   </metadata>
   <files>

--- a/docs/WALKTHROUGH.md
+++ b/docs/WALKTHROUGH.md
@@ -60,7 +60,7 @@ This will prompt you to authenticate again and consent to allow the application 
 In addition to the `get-graphitem` cmdlet which returns data as a series of flat lists, you can use `get-graphchilditem` or its alias `gls` to retrieve your personal contacts:
 
 ```powershell
-PS> get-graphitemchilditem me/contacts
+PS> get-graphchilditem me/contacts
 
 Info Type    Preview        Name
 ---- ----    -------        ----
@@ -95,7 +95,7 @@ givenName            : Cosmo
 ...
 ```
 
-#### Easier content through `--ContentColumns`
+#### Easier content through `-ContentColumns`
 
 An alternative to explicitly `select`ing content is to simply add the desired properties from content into returned objects. You can do just that with the `-ContentColumns` option of `Get-GraphChildItem`. Note that while this changes the fields available in the object, the default display output will still only show the four default columns. You can use PowerShell's `select` alias when the display of the value is what matters.
 
@@ -113,7 +113,7 @@ If one of the fields in `Content` has the same name as a field in the containing
 
 #### The `$LASTGRAPHITEMS variable
 
-As with any PowerShell cmdlet that returns a value, the `Get-GraphItem` and `Get-GraphhChildItem` cmdlets can be assigned to a variable for use with other commands or simply to allow you to dump properties of objects and their child objects:
+As with any PowerShell cmdlet that returns a value, the `Get-GraphItem` and `Get-GraphChildItem` cmdlets can be assigned to a variable for use with other commands or simply to allow you to dump properties of objects and their child objects:
 
 ```powershell
 $mycontacts = gls me/contacts
@@ -224,7 +224,7 @@ Path
 
 The Microsoft Graph supports a rich set of query capabilities through its [OData](https://www.odata.org) support. You can learn the the specifics of MS Graph and OData query specification as part of MS Graph REST Uri's via [Graph's query documentation](https://developer.microsoft.com/en-us/graph/docs/concepts/query_parameters), the [OData query tutorial](http://www.odata.org/getting-started/basic-tutorial/#queryData), or simply by using the [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer).
 
-To use AutoGraphPS's query capabilities are exposed in the `Get-GraphItem` and `Get-GetGraphChildItem` cmdletes (`ggi` and `gls` aliases respectively). To use them, you don't need to construct query Uri's as you might if you were making direct use of OData. And in most cases you will not need to know very much about OData.
+AutoGraphPS's query capabilities are exposed in the `Get-GraphItem` and `Get-GetGraphChildItem` cmdletes (`ggi` and `gls` aliases respectively). To use them, you don't need to construct query Uri's as you might if you were making direct use of OData. And in most cases you will not need to know very much about OData.
 
 ### Filtering data with `-ODataFilter`
 
@@ -630,7 +630,7 @@ https://graph.microsoft.com/v1.0/me/drive/root/children/{driveItem}
 
 The `{driveItem}` segment tells you format of a hypothetical segment that could follow `children`, as well as the type (`driveItem`), allowing tools provide developers hints about possible queries and the data they can return.
 
-### USing Get-GraphToken with other Graph tools
+### Using Get-GraphToken with other Graph tools
 
 When using tools like Postman or Fiddler to troubleshoot or test the Graph, you'll need to acquire a token. Token acquisition continues to be one of the biggest barriers to using Graph, so use AutoGraphPS's `Get-GraphToken` cmdlet to automate it:
 

--- a/docs/WALKTHROUGH.md
+++ b/docs/WALKTHROUGH.md
@@ -80,7 +80,7 @@ Items with a `+` in the `Info` field returned by `Get-GraphItemWithMetadata` con
 Get-Graphitem me/contacts/XMKDFX1
 ```
 
-which returns the contact with `id` `XMKDFX1` may also be retrieved through the sequence below through `Get-GraphItemWithMetadata` (alias `gls`) with a `Select` for the `Content` prpoerty on the first result:
+which returns the contact with `id` `XMKDFX1` may also be retrieved through the sequence below through `Get-GraphItemWithMetadata` (alias `gls`) with a `Select` for the `Content` property on the first result:
 
 ```
 PS> gls me | select -expandproperty content -first 1
@@ -113,7 +113,7 @@ gls me/contacts | foreach { [PSCustomObject] @{Info=$_.Info; Preview=$_.Preview;
 
 If one of the fields in `Content` has the same name as a field in the containing object, it will be prepended with a `_` character when added to it in order to resolve the conflict.
 
-#### The `$LASTGRAPHITEMS variable
+#### The `$LASTGRAPHITEMS` variable
 
 As with any PowerShell cmdlet that returns a value, the `Get-GraphItem`, `Get-GraphItemWithMetadata`, `Get-GraphChildItem` cmdlets can be assigned to a variable for use with other commands or simply to allow you to dump properties of objects and their child objects:
 
@@ -148,7 +148,7 @@ This makes ad-hoc exploration of the Graph less expensive -- you don't have to q
 
 Note that `Get-GraphChildItem` is similar to `Get-GraphItemWithMetadata`, except it does not exhibit the behavior in (2) above, it always exhibits both (1) and (3) at the same time.
 
-This makes `Get-GraphItemWithMetadata` / `gls` / `Get-GraphChildItem` an effective way to recursively discover the Uris for both Graph data and structure (metadata).
+This makes the `Get-GraphItemWithMetadata` / `gls` and `Get-GraphChildItem` commands effective ways to recursively discover the Uris for both Graph data and structure (metadata).
 
 ### Explore new locations
 
@@ -229,7 +229,7 @@ Path
 
 The Microsoft Graph supports a rich set of query capabilities through its [OData](https://www.odata.org) support. You can learn the the specifics of MS Graph and OData query specification as part of MS Graph REST Uri's via [Graph's query documentation](https://developer.microsoft.com/en-us/graph/docs/concepts/query_parameters), the [OData query tutorial](http://www.odata.org/getting-started/basic-tutorial/#queryData), or simply by using the [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer).
 
-AutoGraphPS's query capabilities are exposed in the `Get-GraphItem` and `Get-GetGraphChildItem` cmdletes (`ggi` and `gls` aliases respectively). To use them, you don't need to construct query Uri's as you might if you were making direct use of OData. And in most cases you will not need to know very much about OData.
+AutoGraphPS's query capabilities are exposed in the `Get-GraphItem` `Get-GetGraphItemWithMetadata` (`ggi` and `gls` aliases respectively), and `Get-GraphChildItem` commands. To use them, you don't need to construct query Uri's as you might if you were making direct use of OData. And in most cases you will not need to know very much about OData.
 
 ### Filtering data with `-ODataFilter`
 

--- a/src/cmdlets.ps1
+++ b/src/cmdlets.ps1
@@ -28,3 +28,6 @@
 . (import-script cmdlets\Show-GraphHelp)
 . (import-script cmdlets\Update-GraphMetadata)
 
+# Add parameter completion to commands exported by a different module as a UX enhancement
+$::.ParameterCompleter |=> RegisterParameterCompleter Invoke-GraphRequest RelativeUri (new-so GraphUriParameterCompleter ([GraphUriCompletionType]::LocationOrMethodUri ))
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem ItemRelativeUri (new-so GraphUriParameterCompleter ([GraphUriCompletionType]::LocationOrMethodUri ))

--- a/src/cmdlets/Get-GraphChildItem.ps1
+++ b/src/cmdlets/Get-GraphChildItem.ps1
@@ -69,3 +69,5 @@ function Get-GraphChildItem {
 
     Get-GraphItemWithMetadata @targetParameters
 }
+
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-Childtem ItemRelativeUri (new-so GraphUriParameterCompleter ([GraphUriCompletionType]::LocationOrMethodUri ))


### PR DESCRIPTION
## AutoGraphPS 0.29.0 Release Notes

This release updates the autographps-sdk dependency to 0.16.0 to obtain fixes and
minor improvements.

### New dependencies

* AutoGraphPS-SDK 0.16.0

### Breaking changes
None.

### New features

* URI parameter completion is enabled for the following commands exposed by AutoGraphPS-SDK: `Get-GraphItem`, `Invoke-GraphRequest`.

The following new features originate from the AutoGraphPS-SDK 0.16.0 dependency:

* The `Get-GraphLog` command has a new `StatusFilter` parameter that specifies that the command must return only log etnries with an error status, only those with a success status, or any status (the default).

### Fixed defects

* Fixed missing uri parameter completion for Get-GraphChildItem
* Commands such as `New-GraphApplication` from AutoGraphPS-SDK failed if the current graph location set by `Set-GraphLocation` was no the root (default) -- this is fixed so that commands for managing applications such as `New-GraphApplication` are no longer influenced by the current graph location.

Also, see the release notes for AutoGraphPS-SDK 0.16.0 which inclues these fixes:

* Application management commands such as `New-GraphApplication` would fail due to a bad URI when used by a module like *AutoGraphPS* that allows the default base URI to be changed -- fixed so that URIs used by the application management commands are context invariant.

### Checklist

- [x] All project tests pass successfully
