### PR TITLE
Wait for metadata by default 

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,14 +6,11 @@
 * Fix gls of the result of gls to return the same thing, not the entityset
 * Show-GraphHelp should take a uri
 * Get-GraphType should take a URI
-* Remove default of not waiting for metadata
-* Set-GraphItem should take an object, not just a hashtable
 * Can we use requires to load assemblies in autographps? Probably not, as we need to pick the right platform, unless we do some strange tricks
 * Wrapper for ggci to only support "global" types
 * Use @odata.type when it is present (apparently when type is ambiguous because a collection can contain any type)
 * Use https://github.com/PowerShell/platyPS to generate markdown help
 * Should 'type' be 'resource' or 'resourcetype'?
-* Should Get-GraphResource be Get-GraphContent?
 * Invoke-GraphMethod
 * Format-GraphItem
 * Make new-graphitem return specific error message when you try to create an item by type only that does not have an entityset
@@ -337,6 +334,8 @@
 * Change FromObject to FromItem
 * Change ToObject to ToItem
 * Implement new Get-GraphUri command
+* Remove default of not waiting for metadata
+* Set-GraphItem should take an object, not just a hashtable
 
 ### Postponed
 
@@ -363,6 +362,8 @@
 * Make public graph items have id instead of name
 * switch to 3 columns by default -- remove class
 * Move some data to info, possibly show rwx
+* Should Get-GraphResource be Get-GraphContent?
+  * No :) -- made a Get-GraphContent alias though
 
 #### Stdposh improvements
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,7 @@
 
 ## To-do items -- prioritized
 
+* Fix gls to use begin, end, process!
 * gls and co. should use TypeName instead of FullTypeName, something else other than type
 * Fix gls of the result of gls to return the same thing, not the entityset
 * Show-GraphHelp should take a uri
@@ -22,6 +23,7 @@
 * Make setdefaultvalues in new-graphobject take effect
 * Fix directory header inconsistency which used graph qualified paths in some cases, others no graph
 * Add methods to Get-GraphType
+  * $edges = $graph.typevertices['microsoft.graph.user'].outgoingedges; $edges.keys |where { $edgeName = $_; $edge = $edges[$edgeName]; if ( $edge.transition.type -eq 'Action' -or $edge.transition.type -eq 'Function' ) { $true } } | foreach { $edges[$_] }
 * Add method invocation via Invoke-GraphMethod
 * Fix CI on Linux to actually fail when test failures occur
 * Get-GraphType and New-GraphObject should accept both fqn and uqn instead of just uqn for primitive types as for other type classes

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -353,6 +353,7 @@
 * Rename propertylist in new-graphitem, new-graphobject to propertymap
 * Add-GraphItemReference
 * Fix qualified / vs. unqualified names in metadata classes
+* Fix parameter completion for multiple type classes
 
 ### Abandoned
 

--- a/src/cmdlets/Add-GraphRelatedItem.ps1
+++ b/src/cmdlets/Add-GraphRelatedItem.ps1
@@ -132,8 +132,8 @@ function Add-GraphRelatedItem {
 }
 
 $::.ParameterCompleter |=> RegisterParameterCompleter Add-GraphRelatedItem TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter Add-GraphRelatedItem Property (new-so TypeUriParameterCompleter Property $true Property TypeName Relationship)
-$::.ParameterCompleter |=> RegisterParameterCompleter Add-GraphRelatedItem Relationship (new-so TypeUriParameterCompleter Property $true NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter Add-GraphRelatedItem Property (new-so TypeUriParameterCompleter Property $false Property TypeName Relationship)
+$::.ParameterCompleter |=> RegisterParameterCompleter Add-GraphRelatedItem Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
 $::.ParameterCompleter |=> RegisterParameterCompleter Add-GraphRelatedItem GraphName (new-so GraphParameterCompleter)
 
 

--- a/src/cmdlets/Get-GraphChildItem.ps1
+++ b/src/cmdlets/Get-GraphChildItem.ps1
@@ -60,14 +60,8 @@ function Get-GraphChildItem {
         [parameter(parametersetname='byobjectandpropertyfilter', mandatory=$true)]
         [string] $PropertyFilter,
 
-        [parameter(parametersetname='bytypecollection')]
-        [parameter(parametersetname='byuri')]
-        [parameter(parametersetname='byobject')]
         [string]$Filter,
 
-        [parameter(parametersetname='bytypecollection')]
-        [parameter(parametersetname='byuri')]
-        [parameter(parametersetname='byobject')]
         [Alias('SearchString')]
         $SimpleMatch,
 
@@ -90,6 +84,11 @@ function Get-GraphChildItem {
     )
     begin {
         Enable-ScriptClassVerbosePreference
+
+        if ( $SimpleMatch -and $Filter ) {
+            throw "The SimpleMatch and Filter parameters may not both be specified -- specify only one of these parameters and retry the command."
+        }
+
         $remappedParameters = @{}
         foreach ( $parameterName in $PSBoundParameters.Keys ) {
             if ( $parameterName -ne 'TypeName' -and $parameterName -ne 'Uri' -and $parameterName -ne 'Relationship' -and $parameterName -ne 'Id' -and $parameterName -ne 'SkipPropertyCheck' ) {
@@ -127,10 +126,10 @@ function Get-GraphChildItem {
 }
 
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem Uri (new-so GraphUriParameterCompleter LocationOrMethodUri)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem TypeName (new-so TypeUriParameterCompleter TypeName $true)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem Property (new-so TypeUriParameterCompleter Property $true)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem TypeName (new-so TypeUriParameterCompleter TypeName $false)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem Property (new-so TypeUriParameterCompleter Property $false)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem OrderBy (new-so TypeUriParameterCompleter Property)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem Expand (new-so TypeUriParameterCompleter Property $true NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem Expand (new-so TypeUriParameterCompleter Property $false NavigationProperty)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem GraphName (new-so GraphParameterCompleter)
 

--- a/src/cmdlets/Get-GraphItem.ps1
+++ b/src/cmdlets/Get-GraphItem.ps1
@@ -147,8 +147,8 @@ function Get-GraphItem {
 }
 
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem Property (new-so TypeUriParameterCompleter Property $true)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem Property (new-so TypeUriParameterCompleter Property)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem OrderBy (new-so TypeUriParameterCompleter Property)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem Expand (new-so TypeUriParameterCompleter Property $true NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem Expand (new-so TypeUriParameterCompleter Property $false NavigationProperty)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem GraphName (new-so GraphParameterCompleter)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem Uri (new-so GraphUriParameterCompleter ([GraphUriCompletionType]::LocationOrMethodUri ))

--- a/src/cmdlets/Get-GraphRelatedItem.ps1
+++ b/src/cmdlets/Get-GraphRelatedItem.ps1
@@ -99,6 +99,6 @@ function Get-GraphRelatedItem {
 }
 
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphRelatedItem TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphRelatedItem Relationship (new-so TypeUriParameterCompleter Property $true NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphRelatedItem Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphRelatedItem GraphName (new-so GraphParameterCompleter)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphRelatedItem Uri (new-so GraphUriParameterCompleter LocationUri)

--- a/src/cmdlets/Get-GraphResourceWithMetadata.ps1
+++ b/src/cmdlets/Get-GraphResourceWithMetadata.ps1
@@ -60,7 +60,7 @@ function Get-GraphResourceWithMetadata {
 
         [switch] $DataOnly,
 
-        [Switch] $RequireMetadata,
+        [Switch] $NoRequireMetadata,
 
         [Switch] $StrictOutput,
 
@@ -80,7 +80,7 @@ function Get-GraphResourceWithMetadata {
 
         $context = $null
 
-        $mustWaitForMissingMetadata = $RequireMetadata.IsPresent -or (__Preference__MustWaitForMetadata)
+        $mustWaitForMissingMetadata = (__Preference__MustWaitForMetadata) -and ! $NoRequireMetadata.IsPresent
         $responseContentOnly = $RawContent.IsPresent -or $ContentOnly.IsPresent
 
         $results = @()
@@ -114,6 +114,7 @@ function Get-GraphResourceWithMetadata {
             }
 
             $metadataArgument = @{IgnoreMissingMetadata=(new-object System.Management.Automation.SwitchParameter (! $mustWaitForMissingMetadata))}
+
             Get-GraphUriInfo $targetUri @metadataArgument @GraphArgument -erroraction stop
         } else {
             $context = $::.GraphContext |=> GetCurrent
@@ -225,7 +226,7 @@ function Get-GraphResourceWithMetadata {
         }
 
         if ( $ignoreMetadata ) {
-            write-warning "Metadata processing for Graph is in progress -- responses from Graph will be returned but no metadata will be added. You can retry this cmdlet later or retry it now with the '-RequireMetadata' option to force a wait until processing is complete in order to obtain the complete response."
+            write-warning "Metadata processing for Graph is in progress -- responses from Graph will be returned but no metadata will be added. You can retry this cmdlet later or retry it now with the '-NoRequireMetadata' option unspecified or set to `$false to force a wait until processing is complete in order to obtain the complete response."
         }
 
         if ( ! $DataOnly.ispresent ) {

--- a/src/cmdlets/Get-GraphResourceWithMetadata.ps1
+++ b/src/cmdlets/Get-GraphResourceWithMetadata.ps1
@@ -294,4 +294,4 @@ function Get-GraphResourceWithMetadata {
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceWithMetadata Uri (new-so GraphUriParameterCompleter LocationOrMethodUri)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceWithMetadata Select (new-so TypeUriParameterCompleter Property)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceWithMetadata OrderBy (new-so TypeUriParameterCompleter Property)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceWithMetadata Expand (new-so TypeUriParameterCompleter Property $true NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceWithMetadata Expand (new-so TypeUriParameterCompleter Property $false NavigationProperty)

--- a/src/cmdlets/Get-GraphUri.ps1
+++ b/src/cmdlets/Get-GraphUri.ps1
@@ -82,6 +82,6 @@ function Get-GraphUri {
 }
 
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphUri TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphUri Relationship (new-so TypeUriParameterCompleter Property $true NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphUri Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphUri GraphName (new-so GraphParameterCompleter)
 

--- a/src/cmdlets/Get-GraphUriInfo.ps1
+++ b/src/cmdlets/Get-GraphUriInfo.ps1
@@ -105,9 +105,9 @@ function Get-GraphUriInfo {
 
         $uriSource = $currentUri
         $inputUri = if ( $graphItem ) {
-            $unparsedUri = if ( $graphItem | gm -membertype scriptmethod '__ItemContext' ) {
+            $unparsedUri = if ( $graphItem | gm -membertype scriptmethod '__ItemContext' -erroraction ignore ) {
                 [Uri] ($graphItem |=> __ItemContext | select -expandproperty RequestUri)
-            } elseif ( $graphItem | gm uri ) {
+            } elseif ( $graphItem | gm uri -erroraction ignore ) {
                 $uriSource = $graphItem.uri
                 [Uri] $uriSource
             } else{

--- a/src/cmdlets/Get-GraphUriInfo.ps1
+++ b/src/cmdlets/Get-GraphUriInfo.ps1
@@ -127,7 +127,7 @@ function Get-GraphUriInfo {
 
         write-verbose "Uri '$uriSource' translated to '$inputUri'"
 
-        $mustIgnoreMissingMetadata = $IgnoreMissingMetadata.IsPresent -or (__Preference__MustWaitForMetadata)
+        $mustIgnoreMissingMetadata = $IgnoreMissingMetadata.IsPresent -or ! (__Preference__MustWaitForMetadata)
 
         $contextReady = ($::.GraphManager |=> GetMetadataStatus $context) -eq [MetadataStatus]::Ready
 

--- a/src/cmdlets/New-GraphItem.ps1
+++ b/src/cmdlets/New-GraphItem.ps1
@@ -171,7 +171,7 @@ function New-GraphItem {
 }
 
 $::.ParameterCompleter |=> RegisterParameterCompleter New-GraphItem TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter New-GraphItem Property (new-so TypeUriParameterCompleter Property $true Property TypeName Relationship)
-$::.ParameterCompleter |=> RegisterParameterCompleter New-GraphItem Relationship (new-so TypeUriParameterCompleter Property $true NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter New-GraphItem Property (new-so TypeUriParameterCompleter Property $false Property TypeName Relationship)
+$::.ParameterCompleter |=> RegisterParameterCompleter New-GraphItem Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
 $::.ParameterCompleter |=> RegisterParameterCompleter New-GraphItem GraphName (new-so GraphParameterCompleter)
 

--- a/src/cmdlets/Remove-GraphItemRelationship.ps1
+++ b/src/cmdlets/Remove-GraphItemRelationship.ps1
@@ -125,6 +125,6 @@ function Remove-GraphItemRelationship {
 }
 
 $::.ParameterCompleter |=> RegisterParameterCompleter Remove-GraphItemRelationship TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter Remove-GraphItemRelationship Property (new-so TypeUriParameterCompleter Property $true NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter Remove-GraphItemRelationship Property (new-so TypeUriParameterCompleter Property $false NavigationProperty)
 $::.ParameterCompleter |=> RegisterParameterCompleter Remove-GraphItemRelationship GraphName (new-so GraphParameterCompleter)
 $::.ParameterCompleter |=> RegisterParameterCompleter Remove-GraphItemRelationship Uri (new-so GraphUriParameterCompleter LocationUri)

--- a/src/cmdlets/Set-GraphItem.ps1
+++ b/src/cmdlets/Set-GraphItem.ps1
@@ -149,6 +149,6 @@ function Set-GraphItem {
 }
 
 $::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphItem TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphItem Property (new-so TypeUriParameterCompleter Property $true)
+$::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphItem Property (new-so TypeUriParameterCompleter Property $false)
 $::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphItem ExcludeObjectProperty (new-so TypeUriParameterCompleter Property $false Property $null $null GraphObject)
 $::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphItem GraphName (new-so GraphParameterCompleter)

--- a/src/cmdlets/common/TypeUriHelper.ps1
+++ b/src/cmdlets/common/TypeUriHelper.ps1
@@ -91,11 +91,6 @@ ScriptClass TypeUriHelper {
             $objectUri
         }
 
-        function IsValidEntityType($typeName, $graphContext, $isFullyQualified) {
-            $typeManager = $::.TypeManager |=> Get $graphContext
-            ( $typeManager |=> FindTypeDefinition Entity $typeName $isFullyQualified ) -ne $null
-        }
-
         function GetTypeAwareRequestInfo($graphName, $typeName, $fullyQualifiedTypeName, $uri, $id, $typedGraphObject) {
             $targetContext = $::.ContextHelper |=> GetContextByNameOrDefault $graphName
 
@@ -222,7 +217,7 @@ ScriptClass TypeUriHelper {
                 $::.TypeUriHelper |=> GetTypeAwareRequestInfo $graphName $targetTypeName $isFullyQualifiedTypeName $null $targetObjectId $null
             } else {
                 foreach ( $destinationId in $targetId ) {
-                    $::.TypeUriHelper |=> GetTypeAwareRequestInfo $GraphName $targetTypeName $isFullyQualifiedTypeName $null $destinationId $null
+                    $::.TypeUriHelper |=> GetTypeAwareRequestInfo $GraphName $targetTypeName $isFullyQualifiedTypeName $destinationId $null $null
                 }
             }
         }

--- a/src/cmdlets/common/TypeUriParameterCompleter.ps1
+++ b/src/cmdlets/common/TypeUriParameterCompleter.ps1
@@ -66,12 +66,6 @@ ScriptClass TypeUriParameterCompleter {
         $targetContext = $::.ContextHelper |=> GetContextByNameOrDefault $graphNameParam
 
         $typeName = if ( $typeNameParam ) {
-            if ( $this.propertyTarget ) {
-                if ( ! ( $::.TypeUriHelper |=> IsValidEntityType $typeNameParam $targetContext $this.fullyQualified ) ) {
-                    return
-                }
-            }
-
             if ( $relationshipParam ) {
                 $typeUri = $::.TypeUriHelper |=> DefaultUriForType $targetContext $typeNameParam
                 if ( $typeUri ) {

--- a/src/common/PreferenceHelper.ps1
+++ b/src/common/PreferenceHelper.ps1
@@ -18,7 +18,7 @@ $__GraphMetadataPreferenceValues = @(
     'SilentlyWait'
 )
 
-$GraphMetadataPreference = 'Ignore'
+$GraphMetadataPreference = 'Wait'
 
 function __Preference__ShowNotReadyMetadataWarning {
     if ( $GraphMetadataPreference -ne 'SilentlyWait' ) {
@@ -27,7 +27,7 @@ function __Preference__ShowNotReadyMetadataWarning {
 }
 
 function __Preference__MustWaitForMetadata {
-    $GraphMetadataPreference -eq 'Wait' -and $GraphMetadataPreference -eq 'SilentlyWait'
+    $GraphMetadataPreference -eq 'Wait' -or $GraphMetadataPreference -eq 'SilentlyWait'
 }
 
 $__GraphAutoPromptPreferenceValues = @(

--- a/src/typesystem/TypeManager.ps1
+++ b/src/typesystem/TypeManager.ps1
@@ -52,9 +52,6 @@ ScriptClass TypeManager {
         if ( $hasProperties -or ! ( HasCacheKey $typeId $setDefaultValues $recursive ) ) {
             if ( ! $prototype ) {
                 $type = FindTypeDefinition $typeClass $typeId $true $true
-                if ( ! $type ) {
-                    throw 'anger'
-                }
                 $builder = new-so GraphObjectBuilder $this $type $setDefaultValues $recursive $propertyFilter $valueList $propertyList $skipPropertyCheck
                 $prototype = $builder |=> ToObject
             }
@@ -292,14 +289,19 @@ ScriptClass TypeManager {
 
             $manager = Get $graphContext
 
+            # TODO: The provider's GetSortedTypeNames should take in existing names
+            # as a sorted list and add new items to avoid having to sort everything
+            # when more than one type class is involved.
             $typeNames = foreach ( $targetTypeClass in $typeClasses ) {
                 $typeProvider = $manager |=> __GetTypeProvider $targetTypeClass
                 $typeProvider |=> GetSortedTypeNames $targetTypeClass
             }
 
-            $result = if ( $typeClasses.length -ne 1 ) {
+            $result = if ( $typeClasses.length -eq 1 ) {
                 $typeNames
             } else {
+                # Individual type classes are sorted, but there is more than one
+                # type class here, so we'll just sort everything.
                 $typeNames | sort-object
             }
 

--- a/test/assets/microsoft-directoryservices-fragment.xml
+++ b/test/assets/microsoft-directoryservices-fragment.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+    <edmx:DataServices>
+        <Schema Namespace="microsoft.graph" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+            <EntityType Name="entity" Abstract="true" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+                <Key>
+                    <PropertyRef Name="id" />
+                </Key>
+                <Property Name="id" Type="Edm.String" Nullable="false" />
+            </EntityType>
+            
+            <EntityType Name="directoryObject" BaseType="microsoft.graph.entity" OpenType="true" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+                <Property Name="deletedDateTime" Type="Edm.DateTimeOffset" />
+            </EntityType>
+
+            <EntityType Name="user" BaseType="microsoft.graph.directoryObject" OpenType="true" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+                <Property Name="accountEnabled" Type="Edm.Boolean" />
+                <Property Name="ageGroup" Type="Edm.String" />
+                <Property Name="assignedLicenses" Type="Collection(microsoft.graph.assignedLicense)" Nullable="false" />
+                <Property Name="assignedPlans" Type="Collection(microsoft.graph.assignedPlan)" Nullable="false" />
+                <Property Name="businessPhones" Type="Collection(Edm.String)" Nullable="false" />
+                <Property Name="city" Type="Edm.String" />
+                <Property Name="companyName" Type="Edm.String" />
+                <Property Name="consentProvidedForMinor" Type="Edm.String" />
+                <Property Name="country" Type="Edm.String" />
+                <Property Name="creationType" Type="Edm.String" />
+                <Property Name="department" Type="Edm.String" />
+                <Property Name="displayName" Type="Edm.String" />
+                <Property Name="employeeId" Type="Edm.String" />
+                <Property Name="faxNumber" Type="Edm.String" />
+                <Property Name="givenName" Type="Edm.String" />
+                <Property Name="imAddresses" Type="Collection(Edm.String)" />
+                <Property Name="isResourceAccount" Type="Edm.Boolean" />
+                <Property Name="jobTitle" Type="Edm.String" />
+                <Property Name="lastPasswordChangeDateTime" Type="Edm.DateTimeOffset" />
+                <Property Name="legalAgeGroupClassification" Type="Edm.String" />
+                <Property Name="licenseAssignmentStates" Type="Collection(microsoft.graph.licenseAssignmentState)" />
+                <Property Name="mail" Type="Edm.String" />
+                <Property Name="mailNickname" Type="Edm.String" />
+                <Property Name="mobilePhone" Type="Edm.String" />
+                <Property Name="onPremisesDistinguishedName" Type="Edm.String" />
+                <Property Name="onPremisesExtensionAttributes" Type="microsoft.graph.onPremisesExtensionAttributes" />
+                <Property Name="onPremisesImmutableId" Type="Edm.String" />
+                <Property Name="onPremisesLastSyncDateTime" Type="Edm.DateTimeOffset" />
+                <Property Name="onPremisesProvisioningErrors" Type="Collection(microsoft.graph.onPremisesProvisioningError)" />
+                <Property Name="onPremisesSecurityIdentifier" Type="Edm.String" />
+                <Property Name="onPremisesSyncEnabled" Type="Edm.Boolean" />
+                <Property Name="onPremisesDomainName" Type="Edm.String" />
+                <Property Name="onPremisesSamAccountName" Type="Edm.String" />
+                <Property Name="onPremisesUserPrincipalName" Type="Edm.String" />
+                <Property Name="otherMails" Type="Collection(Edm.String)" Nullable="false" />
+                <Property Name="passwordPolicies" Type="Edm.String" />
+                <Property Name="passwordProfile" Type="microsoft.graph.passwordProfile" />
+                <Property Name="officeLocation" Type="Edm.String" />
+                <Property Name="postalCode" Type="Edm.String" />
+                <Property Name="preferredLanguage" Type="Edm.String" />
+                <Property Name="provisionedPlans" Type="Collection(microsoft.graph.provisionedPlan)" Nullable="false" />
+                <Property Name="proxyAddresses" Type="Collection(Edm.String)" Nullable="false" />
+                <Property Name="showInAddressList" Type="Edm.Boolean" />
+                <Property Name="signInSessionsValidFromDateTime" Type="Edm.DateTimeOffset" />
+                <Property Name="state" Type="Edm.String" />
+                <Property Name="streetAddress" Type="Edm.String" />
+                <Property Name="surname" Type="Edm.String" />
+                <Property Name="usageLocation" Type="Edm.String" />
+                <Property Name="userPrincipalName" Type="Edm.String" />
+                <Property Name="userType" Type="Edm.String" />
+                <Property Name="mailboxSettings" Type="microsoft.graph.mailboxSettings" />
+                <Property Name="deviceEnrollmentLimit" Type="Edm.Int32" Nullable="false" />
+                <Property Name="aboutMe" Type="Edm.String" />
+                <Property Name="birthday" Type="Edm.DateTimeOffset" Nullable="false" />
+                <Property Name="hireDate" Type="Edm.DateTimeOffset" Nullable="false" />
+                <Property Name="interests" Type="Collection(Edm.String)" />
+                <Property Name="mySite" Type="Edm.String" />
+                <Property Name="pastProjects" Type="Collection(Edm.String)" />
+                <Property Name="preferredName" Type="Edm.String" />
+                <Property Name="responsibilities" Type="Collection(Edm.String)" />
+                <Property Name="schools" Type="Collection(Edm.String)" />
+                <Property Name="skills" Type="Collection(Edm.String)" />
+                <NavigationProperty Name="ownedDevices" Type="Collection(microsoft.graph.directoryObject)" />
+                <NavigationProperty Name="registeredDevices" Type="Collection(microsoft.graph.directoryObject)" />
+                <NavigationProperty Name="manager" Type="microsoft.graph.directoryObject" />
+                <NavigationProperty Name="directReports" Type="Collection(microsoft.graph.directoryObject)" />
+                <NavigationProperty Name="memberOf" Type="Collection(microsoft.graph.directoryObject)" />
+                <NavigationProperty Name="createdObjects" Type="Collection(microsoft.graph.directoryObject)" />
+                <NavigationProperty Name="ownedObjects" Type="Collection(microsoft.graph.directoryObject)" />
+                <NavigationProperty Name="licenseDetails" Type="Collection(microsoft.graph.licenseDetails)" ContainsTarget="true" />
+                <NavigationProperty Name="transitiveMemberOf" Type="Collection(microsoft.graph.directoryObject)" />
+                <NavigationProperty Name="outlook" Type="microsoft.graph.outlookUser" ContainsTarget="true" />
+                <NavigationProperty Name="messages" Type="Collection(microsoft.graph.message)" ContainsTarget="true" />
+                <NavigationProperty Name="mailFolders" Type="Collection(microsoft.graph.mailFolder)" ContainsTarget="true" />
+                <NavigationProperty Name="calendar" Type="microsoft.graph.calendar" ContainsTarget="true" />
+                <NavigationProperty Name="calendars" Type="Collection(microsoft.graph.calendar)" ContainsTarget="true" />
+                <NavigationProperty Name="calendarGroups" Type="Collection(microsoft.graph.calendarGroup)" ContainsTarget="true" />
+                <NavigationProperty Name="calendarView" Type="Collection(microsoft.graph.event)" ContainsTarget="true" />
+                <NavigationProperty Name="events" Type="Collection(microsoft.graph.event)" ContainsTarget="true" />
+                <NavigationProperty Name="people" Type="Collection(microsoft.graph.person)" ContainsTarget="true" />
+                <NavigationProperty Name="contacts" Type="Collection(microsoft.graph.contact)" ContainsTarget="true" />
+                <NavigationProperty Name="contactFolders" Type="Collection(microsoft.graph.contactFolder)" ContainsTarget="true" />
+                <NavigationProperty Name="inferenceClassification" Type="microsoft.graph.inferenceClassification" ContainsTarget="true" />
+                <NavigationProperty Name="photo" Type="microsoft.graph.profilePhoto" ContainsTarget="true" />
+                <NavigationProperty Name="photos" Type="Collection(microsoft.graph.profilePhoto)" ContainsTarget="true" />
+                <NavigationProperty Name="drive" Type="microsoft.graph.drive" ContainsTarget="true" />
+                <NavigationProperty Name="drives" Type="Collection(microsoft.graph.drive)" ContainsTarget="true" />
+                <NavigationProperty Name="extensions" Type="Collection(microsoft.graph.extension)" ContainsTarget="true" />
+                <NavigationProperty Name="managedDevices" Type="Collection(microsoft.graph.managedDevice)" ContainsTarget="true" />
+                <NavigationProperty Name="managedAppRegistrations" Type="Collection(microsoft.graph.managedAppRegistration)" />
+                <NavigationProperty Name="deviceManagementTroubleshootingEvents" Type="Collection(microsoft.graph.deviceManagementTroubleshootingEvent)" ContainsTarget="true" />
+                <NavigationProperty Name="planner" Type="microsoft.graph.plannerUser" ContainsTarget="true" />
+                <NavigationProperty Name="insights" Type="microsoft.graph.officeGraphInsights" ContainsTarget="true" />
+                <NavigationProperty Name="settings" Type="microsoft.graph.userSettings" ContainsTarget="true" />
+                <NavigationProperty Name="onenote" Type="microsoft.graph.onenote" ContainsTarget="true" />
+                <NavigationProperty Name="activities" Type="Collection(microsoft.graph.userActivity)" ContainsTarget="true" />
+                <NavigationProperty Name="onlineMeetings" Type="Collection(microsoft.graph.onlineMeeting)" ContainsTarget="true" />
+                <NavigationProperty Name="joinedTeams" Type="Collection(microsoft.graph.group)" ContainsTarget="true" />
+            </EntityType>
+
+            <EntityContainer Name="GraphService">
+                <EntitySet Name="users" EntityType="microsoft.graph.user" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+                    <NavigationPropertyBinding Path="createdObjects" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="directReports" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="drive/items/createdByUser" Target="users" />
+                    <NavigationPropertyBinding Path="drive/items/lastModifiedByUser" Target="users" />
+                    <NavigationPropertyBinding Path="manager" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="memberOf" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="ownedDevices" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="ownedObjects" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="registeredDevices" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="transitiveMemberOf" Target="directoryObjects" />
+                </EntitySet>
+
+                <Singleton Name="me" Type="microsoft.graph.user" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+                    <NavigationPropertyBinding Path="createdObjects" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="directReports" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="manager" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="memberOf" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="ownedDevices" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="ownedObjects" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="registeredDevices" Target="directoryObjects" />
+                    <NavigationPropertyBinding Path="transitiveMemberOf" Target="directoryObjects" />
+                </Singleton>
+            </EntityContainer>
+            <Annotations>
+            </Annotations>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
### Description

Previously, commands that used metadata would continue without it if it had not been processed, generating incomplete results in exchange for better performance. Since this only occurs for a brief period after the module is loaded, and performance is much better than when metadata was first introduced, the default is being changed to block on metadata processing in the name of predictable automation, rather than automation that sometimes returns incomplete results and thus causes unpredictable, hard to troubleshoot failures.

### Checklist

- [x] All project tests pass successfully

