### PR TITLE
Add SimpleMatch and PropertyFilter parameters to Get-GraphResourceWithMetadata

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,7 @@
 
 ## To-do items -- prioritized
 
+* Optimize performance for pipeline scenarios for get-graphitem, get-graphchilditem
 * Show-GraphHelp should take a uri
 * Get-GraphType should take a URI
 * Can we use requires to load assemblies in autographps? Probably not, as we need to pick the right platform, unless we do some strange tricks

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,6 @@
 
 ## To-do items -- prioritized
 
-* Fix gls to use begin, end, process!
 * gls and co. should use TypeName instead of FullTypeName, something else other than type
 * Fix gls of the result of gls to return the same thing, not the entityset
 * Show-GraphHelp should take a uri

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,8 @@
 
 ## To-do items -- prioritized
 
-* Optimize performance for pipeline scenarios for get-graphitem, get-graphchilditem
+* Add trace-graphrequest / measure-graphrequest commands
+* Add progress for pipeline operations
 * Show-GraphHelp should take a uri
 * Get-GraphType should take a URI
 * Can we use requires to load assemblies in autographps? Probably not, as we need to pick the right platform, unless we do some strange tricks
@@ -337,6 +338,7 @@
 * Remove default of not waiting for metadata
 * Set-GraphItem should take an object, not just a hashtable
 * gls and co. should use TypeName instead of FullTypeName, something else other than type
+* Optimize performance for pipeline scenarios for get-graphitem, get-graphchilditem
 
 ### Postponed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,8 +2,6 @@
 
 ## To-do items -- prioritized
 
-* gls and co. should use TypeName instead of FullTypeName, something else other than type
-* Fix gls of the result of gls to return the same thing, not the entityset
 * Show-GraphHelp should take a uri
 * Get-GraphType should take a URI
 * Can we use requires to load assemblies in autographps? Probably not, as we need to pick the right platform, unless we do some strange tricks
@@ -337,6 +335,7 @@
 * Implement new Get-GraphUri command
 * Remove default of not waiting for metadata
 * Set-GraphItem should take an object, not just a hashtable
+* gls and co. should use TypeName instead of FullTypeName, something else other than type
 
 ### Postponed
 
@@ -353,6 +352,7 @@
 * Add-GraphItemReference
 * Fix qualified / vs. unqualified names in metadata classes
 * Fix parameter completion for multiple type classes
+* Fix gls of the result of gls to return the same thing, not the entityset
 
 ### Abandoned
 

--- a/autographps.nuspec
+++ b/autographps.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2020</copyright>
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
-      <dependency id="autographps-sdk" version="0.20.0" />
+      <dependency id="autographps-sdk" version="0.21.0" />
     </dependencies>
   </metadata>
   <files>

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -67,7 +67,7 @@ FormatsToProcess = @('./src/cmdlets/common/AutoGraphFormats.ps1xml')
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='autographps-sdk';ModuleVersion='0.20.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='autographps-sdk';ModuleVersion='0.21.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
     @{ModuleName='scriptclass';ModuleVersion='0.20.1';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
 )
 
@@ -221,7 +221,9 @@ This release includes major breaking changes in command names, fixes significant
 
 ### New dependencies
 
-* AutoGraphPS-SDK 0.20.0
+* AutoGraphPS-SDK 0.21.0
+* Microsoft.Identity.Client (MSAL) 4.14.0
+* Microsoft.IdentityModel.Clients.ActiveDirectory (ADAL) 5.2.7
 
 ### Breaking changes
 

--- a/docs/WALKTHROUGH.md
+++ b/docs/WALKTHROUGH.md
@@ -514,6 +514,8 @@ Group 7 Access Level Just the description
 Both the `GraphObject` and `PropertyMap` parameters can be specified simultaneously -- this could be useful for copying parts of one object as a "template" while adding additional properties:
 
 ```powershell
+$existingGroup = Get-GraphItem group 4e5701ac-92b2-42d5-91cf-45f4865d0e70 -ContentOnly
+
 gls -GraphItem $existingGroup -ContentOnly | select description, displayName
 
 mailNickname displayName description
@@ -521,7 +523,6 @@ mailNickname displayName description
              Unused      Unassinged group
 
 $templateGroup = Get-GraphItem group 0b828d58-2f7d-4ec5-92fb-20f0f88aa1a2 -Property displayName, description -ContentOnly
-$existingGroup = Get-GraphItem group 4e5701ac-92b2-42d5-91cf-45f4865d0e70 -ContentOnly
 
 $existingGroup | Set-GraphItem -GraphObject $templateGroup -PropertyMap @{mailNickName='dorateam'}
 
@@ -565,7 +566,7 @@ This adds a directional relationship between the group and the user "group is re
 To see the new relationship, use the `Get-GraphRelatedItem` command:
 
 ```powershell
-PS> Get-GraphRelatedItem group $newgroup.id -WithRelationship members
+Get-GraphRelatedItem group $newgroup.id -WithRelationship members
 
    Graph Location: /v1.0:/groups/053850da-691d-4605-9bda-6b3d74c7addb/members
 

--- a/src/cmdlets/Get-GraphChildItem.ps1
+++ b/src/cmdlets/Get-GraphChildItem.ps1
@@ -27,19 +27,20 @@ function Get-GraphChildItem {
         [Alias('OfUri')]
         [Uri] $Uri,
 
-        [parameter(parametersetname='byobject', mandatory=$true)]
-        [parameter(parametersetname='byobjectandpropertyfilter', mandatory=$true)]
+        [parameter(parametersetname='byobject', valuefrompipeline=$true, mandatory=$true)]
+        [parameter(parametersetname='byobjectandpropertyfilter', valuefrompipeline=$true, mandatory=$true)]
         [Alias('OfObject')]
         [PSCustomObject] $GraphItem,
 
         [parameter(position=0, parametersetname='bytypecollection', mandatory=$true)]
         [parameter(position=0, parametersetname='bytypecollectionpropertyfilter', mandatory=$true)]
-        [parameter(position=0, parametersetname='bytypeandid', mandatory=$true)]
+        [parameter(position=0, parametersetname='bytypeandid', valuefrompipelinebypropertyname=$true, mandatory=$true)]
         [parameter(position=0, parametersetname='typeandpropertyfilter', mandatory=$true)]
         [Alias('OfTypeName')]
+        [Alias('FullTypeName')]
         [string] $TypeName,
 
-        [parameter(position=1, parametersetname='bytypeandid', valuefrompipeline=$true, mandatory=$true)]
+        [parameter(position=1, parametersetname='bytypeandid', valuefrompipelinebypropertyname=$true, mandatory=$true)]
         [Alias('OfId')]
         [string] $Id,
 
@@ -49,6 +50,9 @@ function Get-GraphChildItem {
         [parameter(position=2, parametersetname='typeandpropertyfilter')]
         [string[]] $Property,
 
+        [parameter(parametersetname='byobject')]
+        [parameter(parametersetname='byobjectandpropertyfilter')]
+        [parameter(parametersetname='bytypeandid')]
         [Alias('WithRelationship')]
         [string[]] $Relationship,
 
@@ -91,7 +95,7 @@ function Get-GraphChildItem {
 
         $remappedParameters = @{}
         foreach ( $parameterName in $PSBoundParameters.Keys ) {
-            if ( $parameterName -ne 'TypeName' -and $parameterName -ne 'Uri' -and $parameterName -ne 'Relationship' -and $parameterName -ne 'Id' -and $parameterName -ne 'SkipPropertyCheck' ) {
+            if ( $parameterName -notin 'TypeName', 'Uri', 'Relationship', 'Id', 'SkipPropertyCheck', 'GraphItem' ) {
                 $remappedParameters.Add($parameterName, $PSBoundParameters[$parameterName])
             }
         }

--- a/src/cmdlets/Get-GraphChildItem.ps1
+++ b/src/cmdlets/Get-GraphChildItem.ps1
@@ -32,39 +32,49 @@ function Get-GraphChildItem {
         [Alias('OfObject')]
         [PSCustomObject] $GraphItem,
 
+        [parameter(parametersetname='bytypeandidpipe', valuefrompipelinebypropertyname=$true, mandatory=$true)]
+        [parameter(position=0, parametersetname='bytypeandid', mandatory=$true)]
         [parameter(position=0, parametersetname='bytypecollection', mandatory=$true)]
         [parameter(position=0, parametersetname='bytypecollectionpropertyfilter', mandatory=$true)]
-        [parameter(position=0, parametersetname='bytypeandid', valuefrompipelinebypropertyname=$true, mandatory=$true)]
-        [parameter(position=0, parametersetname='typeandpropertyfilter', mandatory=$true)]
         [Alias('OfTypeName')]
         [Alias('FullTypeName')]
         [string] $TypeName,
 
-        [parameter(position=1, parametersetname='bytypeandid', valuefrompipelinebypropertyname=$true, mandatory=$true)]
+        [parameter(parametersetname='bytypeandidpipe', valuefrompipelinebypropertyname=$true, mandatory=$true)]
+        [parameter(position=1, parametersetname='bytypeandid', mandatory=$true)]
         [Alias('OfId')]
         [string] $Id,
 
         [parameter(position=2, parametersetname='byuri')]
         [parameter(position=2, parametersetname='bytypeandid')]
+        [parameter(position=2, parametersetname='bytypeandidpipe')]
         [parameter(position=2, parametersetname='bytypecollection')]
-        [parameter(position=2, parametersetname='typeandpropertyfilter')]
         [string[]] $Property,
 
         [parameter(parametersetname='byobject')]
         [parameter(parametersetname='byobjectandpropertyfilter')]
         [parameter(parametersetname='bytypeandid')]
+        [parameter(parametersetname='bytypeandidpipe')]
         [Alias('WithRelationship')]
         [string[]] $Relationship,
 
+
+        [parameter(parametersetname='byuri')]
+        [parameter(parametersetname='byuriandpropertyfilter')]
+        [parameter(parametersetname='byobject')]
+        [parameter(parametersetname='byobjectandpropertyfilter')]
+        [parameter(parametersetname='bytypecollection')]
+        [parameter(parametersetname='bytypecollectionpropertyfilter')]
+        [parameter(parametersetname='bytypeandidpipe', valuefrompipelinebypropertyname=$true, mandatory=$true)]
+        [parameter(parametersetname='bytypeandid')]
         [string] $GraphName,
 
         [parameter(parametersetname='bytypecollectionpropertyfilter', mandatory=$true)]
-        [parameter(parametersetname='typeandpropertyfilter', mandatory=$true)]
         [parameter(parametersetname='byuriandpropertyfilter', mandatory=$true)]
         [parameter(parametersetname='byobjectandpropertyfilter', mandatory=$true)]
-        [string] $PropertyFilter,
+        [HashTable] $PropertyFilter,
 
-        [string]$Filter,
+        [string] $Filter,
 
         [Alias('SearchString')]
         $SimpleMatch,
@@ -88,6 +98,8 @@ function Get-GraphChildItem {
     )
     begin {
         Enable-ScriptClassVerbosePreference
+
+        $accumulatedItems = @()
 
         if ( $SimpleMatch -and $Filter ) {
             throw "The SimpleMatch and Filter parameters may not both be specified -- specify only one of these parameters and retry the command."
@@ -113,7 +125,11 @@ function Get-GraphChildItem {
         }
 
         if ( ! $Relationship ) {
-            $remappedUris += $baseUri
+            if ( $GraphItem ) {
+                $accumulatedItems += $GraphItem
+            } else {
+                $remappedUris += $baseUri
+            }
         } else {
             foreach ( $relationshipProperty in $RelationShip ) {
                 $remappedUris += ( $baseUri.tostring().trimend('/'), $relationshipProperty -join '/' )
@@ -123,8 +139,13 @@ function Get-GraphChildItem {
 
     end {
         $ignoreProperty = $SkipPropertyCheck.IsPresent -or ( $Relationship -ne $null )
-        foreach ( $remappedUri in $remappedUris ) {
-            Get-GraphItem -Uri $remappedUri @remappedParameters -ChildrenOnly:$true -SkipPropertyCheck:$ignoreProperty
+
+        if ( $accumulatedItems ) {
+            $accumulatedItems | Get-GraphItem @remappedParameters -ChildrenOnly:$true -SkipPropertyCheck:$ignoreProperty
+        } else {
+            foreach ( $remappedUri in $remappedUris ) {
+                Get-GraphItem -Uri $remappedUri @remappedParameters -ChildrenOnly:$true -SkipPropertyCheck:$ignoreProperty
+            }
         }
     }
 }

--- a/src/cmdlets/Get-GraphItem.ps1
+++ b/src/cmdlets/Get-GraphItem.ps1
@@ -21,13 +21,10 @@
 . (import-script common/TypeUriParameterCompleter)
 
 function Get-GraphItem {
-    [cmdletbinding(positionalbinding=$false, supportspaging=$true, defaultparametersetname='bytypeandid')]
+    [cmdletbinding(positionalbinding=$false, supportspaging=$true)]
     param(
         [parameter(position=0, parametersetname='bytypeandid', valuefrompipelinebypropertyname=$true, mandatory=$true)]
         [parameter(position=0, parametersetname='typeandpropertyfilter', mandatory=$true)]
-        [parameter(position=0, parametersetname='bytypeandfilter', mandatory=$true)]
-        [parameter(position=0, parametersetname='bytypeandsearch', mandatory=$true)]
-        [parameter(position=0, parametersetname='bytypeandsimplematch', mandatory=$true)]
         [Alias('FullTypeName')]
         $TypeName,
 
@@ -36,23 +33,14 @@ function Get-GraphItem {
 
         [parameter(position=2, parametersetname='bytypeandid')]
         [parameter(position=2, parametersetname='typeandpropertyfilter')]
-        [parameter(position=2, parametersetname='bytypeandfilter')]
-        [parameter(position=2, parametersetname='bytypeandsimplematch')]
         [parameter(position=2, parametersetname='byuri')]
-        [parameter(position=2, parametersetname='byuriandfilter')]
-        [parameter(position=2, parametersetname='byobjectandfilter')]
         [string[]] $Property,
 
         [parameter(parametersetname='byuri', mandatory=$true)]
-        [parameter(parametersetname='byuriandfilter', mandatory=$true)]
-        [parameter(parametersetname='byuriandsimplematch', mandatory=$true)]
-        [parameter(parametersetname='byuriandsearch', valuefrompipeline=$true, mandatory=$true)]
         [parameter(parametersetname='byuriandpropertyfilter', mandatory=$true)]
         [Uri] $Uri,
 
         [parameter(parametersetname='byobject', valuefrompipeline=$true, mandatory=$true)]
-        [parameter(parametersetname='byobjectandfilter', valuefrompipeline=$true, mandatory=$true)]
-        [parameter(parametersetname='byobjectandsearch', valuefrompipeline=$true, mandatory=$true)]
         [parameter(parametersetname='byobjectandpropertyfilter', valuefrompipeline=$true, mandatory=$true)]
         [PSCustomObject] $GraphItem,
 
@@ -63,20 +51,11 @@ function Get-GraphItem {
         [parameter(parametersetname='byobjectandpropertyfilter', mandatory=$true)]
         $PropertyFilter,
 
-        [parameter(parametersetname='bytypeandfilter', mandatory=$true)]
-        [parameter(parametersetname='byuriandfilter', mandatory=$true)]
-        [parameter(parametersetname='byobjectandfilter', mandatory=$true)]
         $Filter,
 
-        [parameter(parametersetname='bytypeandsimplematch', mandatory=$true)]
-        [parameter(parametersetname='byuriandsimplematch', mandatory=$true)]
-        [parameter(parametersetname='byobjectandsimplematch', mandatory=$true)]
         [Alias('SearchString')]
         $SimpleMatch,
 
-        [parameter(parametersetname='bytypeandsearch', mandatory=$true)]
-        [parameter(parametersetname='byuriandsearch', mandatory=$true)]
-        [parameter(parametersetname='byobjectandsearch', mandatory=$true)]
         [String] $Search,
 
         [string[]] $Expand,

--- a/src/cmdlets/Get-GraphItem.ps1
+++ b/src/cmdlets/Get-GraphItem.ps1
@@ -23,14 +23,15 @@
 function Get-GraphItem {
     [cmdletbinding(positionalbinding=$false, supportspaging=$true, defaultparametersetname='bytypeandid')]
     param(
-        [parameter(position=0, parametersetname='bytypeandid', mandatory=$true)]
+        [parameter(position=0, parametersetname='bytypeandid', valuefrompipelinebypropertyname=$true, mandatory=$true)]
         [parameter(position=0, parametersetname='typeandpropertyfilter', mandatory=$true)]
         [parameter(position=0, parametersetname='bytypeandfilter', mandatory=$true)]
-        [parameter(position=0, parametersetname='bytypeandsearch', valuefrompipeline=$true, mandatory=$true)]
+        [parameter(position=0, parametersetname='bytypeandsearch', mandatory=$true)]
         [parameter(position=0, parametersetname='bytypeandsimplematch', mandatory=$true)]
+        [Alias('FullTypeName')]
         $TypeName,
 
-        [parameter(position=1, parametersetname='bytypeandid', valuefrompipeline=$true, mandatory=$true)]
+        [parameter(position=1, parametersetname='bytypeandid', valuefrompipelinebypropertyname=$true, mandatory=$true)]
         $Id,
 
         [parameter(position=2, parametersetname='bytypeandid')]

--- a/src/cmdlets/Get-GraphItemUri.ps1
+++ b/src/cmdlets/Get-GraphItemUri.ps1
@@ -125,6 +125,6 @@ function Get-GraphItemUri {
 }
 
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItemUri TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItemUri Relationship (new-so TypeUriParameterCompleter Property $true NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItemUri Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItemUri GraphName (new-so GraphParameterCompleter)
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItemUri Uri (new-so GraphUriParameterCompleter LocationUri)

--- a/src/cmdlets/Get-GraphRelatedItem.ps1
+++ b/src/cmdlets/Get-GraphRelatedItem.ps1
@@ -89,12 +89,13 @@ function Get-GraphRelatedItem {
                 $::.QueryTranslationHelper |=> ValidatePropertyProjection $requestInfo.Context $requestInfo.TypeInfo $currentRelationship NavigationProperty
             }
 
-            $requestInfo.Uri.ToString(), $currentRelationship -join '/'
+            [Uri] ( $::.GraphUtilities |=> ToLocationUriPath $requestInfo.context ( $requestInfo.Uri.ToString(), $currentRelationship -join '/' ) )
         }
     }
 
     end {
-        $relationshipUris | Get-GraphResourceWithMetadata -GraphName $GraphName -ContentOnly:$($ContentOnly.IsPresent) -ErrorAction $requestErrorAction
+        $graphNameArgument = if ( $GraphName ) { @{GraphName=$GraphName} } else { @{} }
+        $relationshipUris | Get-GraphResourceWithMetadata @graphNameArgument -ContentOnly:$($ContentOnly.IsPresent) -ErrorAction $requestErrorAction
     }
 }
 

--- a/src/cmdlets/common/SegmentHelper.ps1
+++ b/src/cmdlets/common/SegmentHelper.ps1
@@ -121,6 +121,7 @@ ScriptClass SegmentHelper {
                 Id = $segment.name
                 Namespace = $namespace
                 Uri = $Uri
+                GraphName = $parser.context.name
                 GraphUri = $relativeUri
                 Path = $path
                 FullTypeName = $fullTypeName
@@ -175,6 +176,7 @@ ScriptClass SegmentHelper {
                 Id = $itemId
                 Namespace = $requestSegment.Namespace
                 Uri = $typeInfo.AbsoluteUri
+                GraphName = $graphContext.Name
                 GraphUri = $typeinfo.GraphUri
                 Path = $typeInfo.FullPath
                 FullTypeName = $fullTypeName

--- a/src/cmdlets/common/SegmentHelper.ps1
+++ b/src/cmdlets/common/SegmentHelper.ps1
@@ -137,10 +137,9 @@ ScriptClass SegmentHelper {
             $result
         }
 
-        function ToPublicSegmentFromGraphItem( $graphContext, $graphItem ) {
-            $itemUri = $::.TypeUriHelper |=> GetUriFromDecoratedObject $graphContext $graphItem $true
+        function ToPublicSegmentFromGraphItem( $graphContext, $graphItem, $requestSegment ) {
+            $typeInfo = $::.TypeUriHelper |=> InferTypeUriInfoFromRequestItem $requestSegment $graphItem
 
-            $typeInfo = $::.TypeUriHelper |=> TypeFromUri $itemUri $graphContext
             $fullTypeName = $typeInfo.FullTypeName
 
             $typeComponents = $fullTypeName -split '\.'
@@ -162,13 +161,11 @@ ScriptClass SegmentHelper {
                 $itemName
             }
 
-            $segment = $typeInfo.UriInfo
-
             # Using ToString() here to work around a strange behavior where
             # PSTypeName does not cause type conversion
             [PSCustomObject] @{
-                PSTypeName = $segment.pstypename.tostring()
-                ParentPath = $segment.Path
+                PSTypeName = $requestSegment.pstypename.tostring()
+                ParentPath = $requestSegment.Path
                 Info = $this.__GetInfoField($false, $true, 'EntityType', $true)
                 Name = $itemName
                 Relation = 'Direct'
@@ -176,16 +173,16 @@ ScriptClass SegmentHelper {
                 Class = 'EntityType'
                 Type = $typeComponents[$typeComponents.length - 1]
                 Id = $itemId
-                Namespace = $segment.Namespace
-                Uri = $segment.Uri
-                GraphUri = $segment.GraphUri
-                Path = $segment.Path
+                Namespace = $requestSegment.Namespace
+                Uri = $typeInfo.AbsoluteUri
+                GraphUri = $typeinfo.GraphUri
+                Path = $typeInfo.FullPath
                 FullTypeName = $fullTypeName
-                Version = $segment.Version
-                Endpoint = $segment.Endpoint
+                Version = $requestSegment.Version
+                Endpoint = $requestSegment.Endpoint
                 IsDynamic = $true
                 Parent = $null
-                Details = $segment
+                Details = $null
                 Content = $graphItem
                 Preview = $this.__GetPreview($graphItem, $itemId)
             }

--- a/src/cmdlets/common/TypeUriHelper.ps1
+++ b/src/cmdlets/common/TypeUriHelper.ps1
@@ -48,6 +48,7 @@ ScriptClass TypeUriHelper {
             if ( $responseObject | gm -membertype scriptmethod __ItemContext -erroraction ignore ) {
                 $requestUri = $::.GraphUtilities |=> ParseGraphUri $responseObject.__ItemContext().RequestUri $targetContext
                 $objectUri = $requestUri.GraphRelativeUri
+                $uriInfo = Get-GraphUriInfo $objectUri
 
                 # When an object is supplied, its URI had better end with whatever id was supplied.
                 # This will not always be true of the uri retrieved from the object because this URI is the
@@ -58,7 +59,7 @@ ScriptClass TypeUriHelper {
                 # we can recover the URI if we assume the discrepancy is indeed due to this scenario.
                 # TODO: Get an explicit object URI from the object itself rather than this workaround which
                 # will have problematic corner cases.
-                if ( $resourceId -and ! $objectUri.tostring().tolower().EndsWith("/$($resourceId.tolower())") ) {
+                if ( $uriInfo.Collection -and $resourceId -and ! $objectUri.tostring().tolower().EndsWith("/$($resourceId.tolower())") ) {
                     $objectUri = $objectUri.tostring(), $resourceId -join '/'
                 }
 

--- a/src/cmdlets/common/TypeUriHelper.ps1
+++ b/src/cmdlets/common/TypeUriHelper.ps1
@@ -48,7 +48,9 @@ ScriptClass TypeUriHelper {
             if ( $responseObject | gm -membertype scriptmethod __ItemContext -erroraction ignore ) {
                 $requestUri = $::.GraphUtilities |=> ParseGraphUri $responseObject.__ItemContext().RequestUri $targetContext
                 $objectUri = $requestUri.GraphRelativeUri
-                $uriInfo = Get-GraphUriInfo $objectUri
+                $uriInfo = if ( $resourceId ) {
+                    Get-GraphUriInfo $objectUri
+                }
 
                 # When an object is supplied, its URI had better end with whatever id was supplied.
                 # This will not always be true of the uri retrieved from the object because this URI is the
@@ -59,7 +61,7 @@ ScriptClass TypeUriHelper {
                 # we can recover the URI if we assume the discrepancy is indeed due to this scenario.
                 # TODO: Get an explicit object URI from the object itself rather than this workaround which
                 # will have problematic corner cases.
-                if ( $uriInfo.Collection -and $resourceId -and ! $objectUri.tostring().tolower().EndsWith("/$($resourceId.tolower())") ) {
+                if ( $uriInfo -and $uriInfo.Collection -and $resourceId -and ! $objectUri.tostring().tolower().EndsWith("/$($resourceId.tolower())") ) {
                     $objectUri = $objectUri.tostring(), $resourceId -join '/'
                 }
 
@@ -72,6 +74,25 @@ ScriptClass TypeUriHelper {
         function GetTypeFromDecoratedObject($graphObject) {
             if ( $graphObject | gm -membertype scriptmethod $this.TYPE_METHOD_NAME -erroraction ignore ) {
                 $graphObject.($this.TYPE_METHOD_NAME)()
+            }
+        }
+
+        function InferTypeUriInfoFromRequestItem($requestItem, $responseObject) {
+            $absoluteUri = $requestItem.Uri
+            $fullPath = $requestItem.Path
+            $graphUri = $requestItem.GraphUri
+
+            if ( $requestItem.Collection ) {
+                $absoluteUri = $absoluteUri.trimend('/'), $responseObject.Id -join '/'
+                $fullPath = $fullPath.trimend('/'), $responseObject.Id -join '/'
+                $graphUri = [Uri] ($graphUri.tostring().trimend('/'), $responseObject.Id -join '/')
+            }
+
+            [PSCustomObject] @{
+                FullTypeName = $requestItem.FullTypeName
+                AbsoluteUri = $absoluteUri
+                FullPath = $fullPath
+                GraphUri = $graphUri
             }
         }
 

--- a/src/cmdlets/common/TypeUriHelper.ps1
+++ b/src/cmdlets/common/TypeUriHelper.ps1
@@ -40,7 +40,7 @@ ScriptClass TypeUriHelper {
             # This method handles two cases:
             #
             #   * Objects returned by Get-GraphResource which are decorated with the __ItemContext scriptmethod
-            #   * Oboject returned by Get-GraphResourceWithMetadata which are PSCustomObjects of GraphSgementDisplayType
+            #   * Objects returned by Get-GraphResourceWithMetadata which are PSCustomObjects of GraphSgementDisplayType
             #
             # The latter has a Path member with exactly the uri needed to resolve the object, the other requires
             # a workaround since it may only have a partial URI originally used as the target of a POST that created it.
@@ -137,19 +137,35 @@ ScriptClass TypeUriHelper {
             } elseif ( $uri )  {
                 TypeFromUri $targetUri $targetContext
             } elseif ( $typedGraphObject ) {
-                $objectUri = GetUriFromDecoratedObject $targetContext $typedGraphObject $id
-                if ( $objectUri ) {
-                    $objectUriInfo = TypeFromUri $objectUri $targetContext
-
-                    # TODO: When an object is supplied, it had better end with whatever id was supplied.
-                    # This will not always be true of the uri retrieved from the object
-                    if ( $id -and ( $objectUriInfo.UriInfo.class -in ( 'EntityType', 'EntitySet' ) ) -and ! $objectUri.tostring().tolower().EndsWith("/$($id.tolower())" ) ) {
-                        $correctedUri = $objectUri, $id -join '/'
-                        $objectUriInfo = TypeFromUri $correctedUri $targetContext
+                if (  $::.SegmentHelper |=> IsGraphSegmentType $typedGraphObject ) {
+                    # This is already a fully described object -- no need to make expensive
+                    # calls to parse metadata and understand the object
+                    $objectUri = $typedGraphObject.GraphUri
+                    $targetUri = $objectUri
+                    [PSCustomObject] @{
+                        FullTypeName = $typedGraphObject.FullTypeName
+                        IsCollection = $typedGraphObject.Collection
+                        UriInfo = $typedGraphObject
                     }
+                } else {
+                    # We need to analyze information about the object using its uri since we
+                    # don't have existing information -- this is expensive, so hopefully
+                    # it doesn't occur to often
+                    $objectUri = GetUriFromDecoratedObject $targetContext $typedGraphObject $id
 
-                    $targetUri = $objectUriInfo.UriInfo.graphUri
-                    $objectUriInfo
+                    if ( $objectUri ) {
+                        $objectUriInfo = TypeFromUri $objectUri $targetContext
+
+                        # TODO: When an object is supplied, it had better end with whatever id was supplied.
+                        # This will not always be true of the uri retrieved from the object
+                        if ( $id -and ( $objectUriInfo.UriInfo.class -in ( 'EntityType', 'EntitySet' ) ) -and ! $objectUri.tostring().tolower().EndsWith("/$($id.tolower())" ) ) {
+                            $correctedUri = $objectUri, $id -join '/'
+                            $objectUriInfo = TypeFromUri $correctedUri $targetContext
+                        }
+
+                        $targetUri = $objectUriInfo.UriInfo.graphUri
+                        $objectUriInfo
+                    }
                 }
             }
 


### PR DESCRIPTION
### Description

Adds the parameters `SimpleMatch` and `PropertyFilter` to `Get-GraphResourceWithMetadata` for consistency with `Get-GraphItem` and `Get-GraphChildItem`.

### Checklist

- [ ] All project tests pass successfully

