### PR TITLE
Replace Start-Job with Start-ThreadJob

### DIFF
--- a/autographps.nuspec
+++ b/autographps.nuspec
@@ -14,6 +14,7 @@
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
       <dependency id="autographps-sdk" version="0.21.0" />
+      <dependency id="ThreadJob" version="2.0.3" />
     </dependencies>
   </metadata>
   <files>

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -252,7 +252,7 @@ This release includes major breaking changes in command names, fixes significant
   * `LastTypeMetadataSource`: The source of the type metadata used to define the graph when it was first mounted or last updated, which ever is ost recent. The source is either a URI to an http metadata source like https://graph.microsoft.com/v1.0/$metadata or the path to a local file containing the same format of data as that hosted at the http URI.
 * The `ContentColumns` parameter of `Get-GraphChildItem` and `Get-GraphResourceWithMetadata` has been replaced by the `ContentOnly` parameter which has the following behavior: Instead of returning a uniform `PSCustomObject` with standard members including a `Content` member to access the actual content returned by Graph, the command just returns the actual content, just like the `Get-GraphResource` command.
 * The `Get-GraphChildItem` command now also returns children of a type's entityset if applicable
-* Metadata download and initial processing now uses a thread in the same process hosting AutoGraphPS, rather than a separate process. This offers a dramatic performance improvement in obtaining the API metadata that the commands rely upon. The implementation was simply to move from using `Start-Job` to `Start-ThreadJob`.
+* Metadata download and initial processing now uses a thread in the same process hosting AutoGraphPS, rather than a separate process. This offers a dramatic performance improvement in obtaining the API metadata that the commands rely upon. The new implementation uses `Start-ThreadJob` instead of `Start-Job` to process metadata asynchronously.
 
 ### Fixed defects
 

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.32.0'
+ModuleVersion = '0.33.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -69,6 +69,7 @@ FormatsToProcess = @('./src/cmdlets/common/AutoGraphFormats.ps1xml')
 NestedModules = @(
     @{ModuleName='autographps-sdk';ModuleVersion='0.21.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
     @{ModuleName='scriptclass';ModuleVersion='0.20.1';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
+    @{ModuleName='ThreadJob';ModuleVersion='2.0.3';Guid='0e7b895d-2fec-43f7-8cae-11e8d16f6e40'}
 )
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
@@ -215,55 +216,25 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-## AutoGraphPS 0.32.0 Release Notes
+## AutoGraphPS 0.33.0 Release Notes
 
-This release includes major breaking changes in command names, fixes significant defects in type-related functionality, and adds several features to existing commands. Some commands, such as `Get-GraphChildItem`, gain completely new behaviors.
+This release includes a performance improvement to use threads in the PowerShell process rather than starting separate PowerShell processes for background metadata processing.
 
 ### New dependencies
 
-* AutoGraphPS-SDK 0.21.0
-* Microsoft.Identity.Client (MSAL) 4.14.0
-* Microsoft.IdentityModel.Clients.ActiveDirectory (ADAL) 5.2.7
+* ThreadJob 2.0.3 -- this is the introductory use of ThreadJob for this module
 
 ### Breaking changes
 
-* Includes breaking changes from [AutoGraphPS-SDK 0.19.0](https://github.com/adamedx/autographps-sdk/releases/tag/v0.19.0) -- `Get-GraphItem` and `Remove-GraphItem` from `AutoGraphPS-SDK` have been renamed to `Get-GraphResource` and `Remove-GraphResource`
-* `Get-GraphItemWithMetadata` has been renamed to `Get-GraphResourceWithMetadata`
-* `Get-GraphUri` has been renamed to `Get-GraphUriInfo`
-* New implementations of `Get-GraphItem` and `Remove-GraphItem` are introduced in this module -- previously they were part of `AutoGraphPS-SDK` and had different functionality than the new version in this module
+None.
 
 ### New features
-* New commands for write operations, and other commands as well!
-  * `Add-GraphRelatedItem`: creates a new entity in the graph that is associated with an existing entity through a relationship (i.e. an *OData navigation property*)
-  * `Get-GraphRelatedItem`: returns the items related from one entity to a second entity through a relationship property (*OData navigation property*)
-  * `Get-GraphUri`: returns the URI of an entity given the type and id, or for a URI with a relationship
-  * `New-GraphItem`: creates a new item in the graph
-  * `New-GraphItemRelationship`: creates an association from one entity in the graph to a second entity through a relationship property (*OData navigation property*) of the first entity
-  * `New-GraphObject`: creates a deserialized reprsentation of an item in the graph or of data structures referenced in the graph. The representation can be converted to the same JSON format used to serialize data in requests to the graph
-  * `Remove-GraphItemRelatonship`: removes the association from one entity to a second entity
-  * `Set-GraphItem`: updates an existing entity in the graph
-* `Get-GraphType` now supports tab-completion for output, so commands like select can be used interactively when building commands in the shell
-* New `Get-GraphItem` command: a command with this name was in previous versions of the dependency module `AutoGraphPS-SDK`; this new command supports type-aware access of objects by `id` and other type-related facilities.
-* New `Remove-GraphItem` command: a command with this name was in previous versions of the dependency module `AutoGraphPS-SDK`; this new command supports type-aware removal of objects by `id` and other type-related facilities.
-* `Get-Graph` now returns an object with additional fields providing more information about the context of the Graph:
-  * `Id`: The `Id` field is a guid that uniquely identifies the mounted Graph. If the same graph endpoint is mounted again, it will have a different `Id`. The property can be used for cases such as hashing.
-  * `CreationTime`: The time, in the local time zone, at which the graph was mounted
-  * `LastUpdateTime`: The time, in the local time zone, at which the graph was last updated by the `Update-GraphMetadata` command. If no such update occurred, the time is the same as the `CreationTime` property
-  * `LastTypeMetadataSource`: The source of the type metadata used to define the graph when it was first mounted or last updated, which ever is ost recent. The source is either a URI to an http metadata source like https://graph.microsoft.com/v1.0/$metadata or the path to a local file containing the same format of data as that hosted at the http URI.
-* The `ContentColumns` parameter of `Get-GraphChildItem` and `Get-GraphResourceWithMetadata` has been replaced by the `ContentOnly` parameter which has the following behavior: Instead of returning a uniform `PSCustomObject` with standard members including a `Content` member to access the actual content returned by Graph, the command just returns the actual content, just like the `Get-GraphResource` command.
-* The `Get-GraphChildItem` command now also returns children of a type's entityset if applicable
+
 * Metadata download and initial processing now uses a thread in the same process hosting AutoGraphPS, rather than a separate process. This offers a dramatic performance improvement in obtaining the API metadata that the commands rely upon. The new implementation uses `Start-ThreadJob` instead of `Start-Job` to process metadata asynchronously.
 
 ### Fixed defects
 
-* Graph API versions including `v1.0` and `beta` included multiple namespaces for API metadata after March 2020. Types outside of the `graph.microsoft` namespace were invisible to AutoGraphPS commands -- this has been fixed with support for multiple namespaces.
-* Test execution in CI requires special module-specific logic to rename the AutoGraphPS-SDK modules installed for testing to lower case
-* The `ContentColumns` parameter of `Get-GraphChildItem` and `Get-GraphResourceWithMetadata` has been regressed for several releases due to a syntax error which is now fixed.
-* Inherited properties were absent from objects generated by `New-GraphObject`
-* Inherited properties may be selected for the `Property` argument of `New-GraphObject`
-* Fixed race condition in `Update-GraphMetadata` where some commands like `New-GraphObject` and `Get-GraphType` would not reflect the update
-* Numerous parameter set fixes to `*-GraphItem*` commands including addressing consistency issues with the parameter sets
-* Numerous fixes from commands included from the `AutoGraphPS-SDK` module
+None.
 
 '@
     } # End of PSData hashtable

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -252,16 +252,7 @@ This release includes major breaking changes in command names, fixes significant
   * `LastTypeMetadataSource`: The source of the type metadata used to define the graph when it was first mounted or last updated, which ever is ost recent. The source is either a URI to an http metadata source like https://graph.microsoft.com/v1.0/$metadata or the path to a local file containing the same format of data as that hosted at the http URI.
 * The `ContentColumns` parameter of `Get-GraphChildItem` and `Get-GraphResourceWithMetadata` has been replaced by the `ContentOnly` parameter which has the following behavior: Instead of returning a uniform `PSCustomObject` with standard members including a `Content` member to access the actual content returned by Graph, the command just returns the actual content, just like the `Get-GraphResource` command.
 * The `Get-GraphChildItem` command now also returns children of a type's entityset if applicable
-* The `Get-GraphChildItem`, `Get-GraphItem`, and `Get-GraphResourceWithMetadata` commands now support the following parameters (with parameter-completion where applicable):
-  * Paging parameter support: `First`, `Skip`, `IncludeTotalCount` parameters are now supported (as they are for the `Invoke-GraphRequest` and `Get-GraphResource` commands of `AutoGraphPS-SDK`).
-  * `Expand`: Navigation properties may now be expanded (with parameter completion)
-  * `Search`: For supported entities, an API-defined search query may be specified
-  * `Sort`, `Descending`: Sorting by specified property (with parameter completion) may be specified
-* The `Get-GraphChildItem` and `Get-GraphItem` commands support the `SimpleMatch` parameter that uses a heuristic approach for "casual" graph queries without the need for OData syntax
-* Parameter completion is also supported for the `Expand` and `Sort` commands of `Invoke-GraphRequest` and `Get-GraphResource` when this module is installed.
-* `Show-GraphHelp` supports complex types
-* `Get-GraphType` supports the `TransitiveMembers` parameter and `MemberFilter` parameters
-* Various pipeline improvements have been made to most commands to ensure consistency across commands and enable useful scenarios. In general, pipelines should be easy for the typical PowerShell user to exploit and should adhere to the *Principle of Least Astonishment*.
+* Metadata download and initial processing now uses a thread in the same process hosting AutoGraphPS, rather than a separate process. This offers a dramatic performance improvement in obtaining the API metadata that the commands rely upon. The implementation was simply to move from using `Start-Job` to `Start-ThreadJob`.
 
 ### Fixed defects
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,14 +94,14 @@ jobs:
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests'
-    condition: true # eq(variables.OS_PLATFORM, 'windows') # Only on Windows because this hangs on Linux
+    condition: eq(variables.OS_PLATFORM, 'windows') # Only on Windows because this hangs on Linux
     inputs:
       targetType: inline
-      script: si env:TEST_OUTPUT_PATH "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)"; ./build/import-devmodule.ps1 -initialcommand 'Invoke-Pester -OutputFile $env:TEST_OUTPUT_PATH -OutputFormat NUnitXml' -Wait -ReuseConsole:$($PSVersionTable.platform -ne 'unix')
+      script: si env:TEST_OUTPUT_PATH "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)"; ./build/import-devmodule.ps1 -initialcommand 'Invoke-Pester -OutputFile $env:TEST_OUTPUT_PATH -OutputFormat NUnitXml' -Wait -ReuseConsole
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests directly'
-    condition: false # eq(variables.OS_PLATFORM, 'ubuntu') # Only needed on Linux to avoid hangs
+    condition: eq(variables.OS_PLATFORM, 'ubuntu') # Only needed on Linux to avoid hangs
     inputs:
       targetType: inline
       script: './build/Init-DirectTestRun.ps1 -verbose; Invoke-Pester -OutputFile "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)" -OutputFormat NUnitXml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,14 +94,14 @@ jobs:
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests'
-    condition: eq(true, 'windows') # Only on Windows because this hangs on Linux
+    condition: true # eq(variables.OS_PLATFORM, 'windows') # Only on Windows because this hangs on Linux
     inputs:
       targetType: inline
       script: si env:TEST_OUTPUT_PATH "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)"; ./build/import-devmodule.ps1 -initialcommand 'Invoke-Pester -OutputFile $env:TEST_OUTPUT_PATH -OutputFormat NUnitXml' -Wait -ReuseConsole
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests directly'
-    condition: eq(false) # Only needed on Linux to avoid hangs
+    condition: false #eq(variables.OS_PLATFORM, 'ubuntu') # Only needed on Linux to avoid hangs
     inputs:
       targetType: inline
       script: './build/Init-DirectTestRun.ps1 -verbose; Invoke-Pester -OutputFile "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)" -OutputFormat NUnitXml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,14 +94,14 @@ jobs:
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests'
-    condition: eq(variables.OS_PLATFORM, 'windows') # Only on Windows because this hangs on Linux
+    condition: eq(true, 'windows') # Only on Windows because this hangs on Linux
     inputs:
       targetType: inline
       script: si env:TEST_OUTPUT_PATH "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)"; ./build/import-devmodule.ps1 -initialcommand 'Invoke-Pester -OutputFile $env:TEST_OUTPUT_PATH -OutputFormat NUnitXml' -Wait -ReuseConsole
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests directly'
-    condition: eq(variables.OS_PLATFORM, 'ubuntu') # Only needed on Linux to avoid hangs
+    condition: eq(false) # Only needed on Linux to avoid hangs
     inputs:
       targetType: inline
       script: './build/Init-DirectTestRun.ps1 -verbose; Invoke-Pester -OutputFile "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)" -OutputFormat NUnitXml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,11 +97,11 @@ jobs:
     condition: true # eq(variables.OS_PLATFORM, 'windows') # Only on Windows because this hangs on Linux
     inputs:
       targetType: inline
-      script: si env:TEST_OUTPUT_PATH "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)"; ./build/import-devmodule.ps1 -initialcommand 'Invoke-Pester -OutputFile $env:TEST_OUTPUT_PATH -OutputFormat NUnitXml' -Wait -ReuseConsole
+      script: si env:TEST_OUTPUT_PATH "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)"; ./build/import-devmodule.ps1 -initialcommand 'Invoke-Pester -OutputFile $env:TEST_OUTPUT_PATH -OutputFormat NUnitXml' -Wait -ReuseConsole:$($PSVersionTable.platform -ne 'unix')
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests directly'
-    condition: false #eq(variables.OS_PLATFORM, 'ubuntu') # Only needed on Linux to avoid hangs
+    condition: false # eq(variables.OS_PLATFORM, 'ubuntu') # Only needed on Linux to avoid hangs
     inputs:
       targetType: inline
       script: './build/Init-DirectTestRun.ps1 -verbose; Invoke-Pester -OutputFile "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)" -OutputFormat NUnitXml'

--- a/src/metadata/GraphCache.ps1
+++ b/src/metadata/GraphCache.ps1
@@ -178,7 +178,7 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
         $dependencyModule = 'AutoGraphPS'
         $thiscode = join-path $psscriptroot '../graph.ps1'
 
-        $graphLoadJob = start-job { param($module, $scriptsourcepath, $graphEndpoint, $version, $schemadata, $verbosity) $verbosepreference=$verbosity; $__poshgraph_no_auto_metadata = $true; import-module $module; . $scriptsourcepath; $::.GraphCache |=> __GetGraph $graphEndpoint $version $schemadata } -argumentlist $dependencymodule, $thiscode, $endpoint, $apiVersion, $metadata, $verbosepreference  -name "AutoGraphPS metadata download for '$graphId'"
+        $graphLoadJob = start-threadjob { param($module, $scriptsourcepath, $graphEndpoint, $version, $schemadata, $verbosity) $verbosepreference=$verbosity; $__poshgraph_no_auto_metadata = $true; import-module $module; . $scriptsourcepath; $::.GraphCache |=> __GetGraph $graphEndpoint $version $schemadata } -argumentlist $dependencymodule, $thiscode, $endpoint, $apiVersion, $metadata, $verbosepreference  -name "AutoGraphPS metadata download for '$graphId'"
 
         $graphAsyncJob = [PSCustomObject]@{Job=$graphLoadJob;Id=$graphId}
         write-verbose "Saving job '$($graphLoadJob.Id) for graphid '$graphId'"

--- a/src/metadata/GraphCache.ps1
+++ b/src/metadata/GraphCache.ps1
@@ -175,10 +175,16 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
         write-verbose "Getting async graph for graphid: '$graphId', endpoint: '$endpoint', version: '$apiVersion'"
         write-verbose "Local metadata supplied: '$($metadata -ne $null)'"
 
-        $dependencyModule = 'AutoGraphPS'
-        $thiscode = join-path $psscriptroot '../graph.ps1'
+        $cacheClass = $::.GraphCache
 
-        $graphLoadJob = start-threadjob { param($module, $scriptsourcepath, $graphEndpoint, $version, $schemadata, $verbosity) $verbosepreference=$verbosity; $__poshgraph_no_auto_metadata = $true; import-module $module; . $scriptsourcepath; $::.GraphCache |=> __GetGraph $graphEndpoint $version $schemadata } -argumentlist $dependencymodule, $thiscode, $endpoint, $apiVersion, $metadata, $verbosepreference  -name "AutoGraphPS metadata download for '$graphId'"
+        # Start-ThreadJob starts a ThreadJob, a job running in another thread in this process rather than a separate process. It is much more efficient,
+        # but very strange things occur if ScriptClass method functionality is invoked, possibly because of the way ScriptClass interacts with the call
+        # stack. Due to this, the safest way to pass in ScriptClass state is to pass in an object, and use standard method call syntax rather than
+        # ScriptClass syntax to invoke it. Regardless, Start-ThreadJob is far more efficient than Start-Job AND it doesn't have to serialize and
+        # deserialize objects -- many of the strange workarounds in this module to ensure that ScriptClass object state was preserved is no longer
+        # a necessity, though most of those workarounds are now built in to ScriptClass itself. It may even be feasible to parse the entire graph
+        # rather than only parse just in time since the entire graph can be parsed efficiently in the background without being serialized and deserialized.
+        $graphLoadJob = Start-ThreadJob { param($cacheClass, $graphEndpoint, $version, $schemadata, $verbosity) $verbosepreference=$verbosity; $__poshgraph_no_auto_metadata = $true; $cacheClass.__GetGraph($graphEndpoint, $version, $schemadata) } -argumentlist $cacheClass, $endpoint, $apiVersion, $metadata, $verbosepreference  -name "AutoGraphPS metadata download for '$graphId'"
 
         $graphAsyncJob = [PSCustomObject]@{Job=$graphLoadJob;Id=$graphId}
         write-verbose "Saving job '$($graphLoadJob.Id) for graphid '$graphId'"


### PR DESCRIPTION
### Description

Improve performance and eliminate cross-process marshalling issues through `Start-ThreadJob`. This replaces `Start-Job` in the metadata download and parsing code-path.

### Dependency changes

* `ThreadJob 2.0.3` -- this is the introductory use of `ThreadJob` for this module

### Breaking changes

None.

### New features

* Metadata download and initial processing now uses a thread in the same process hosting AutoGraphPS, rather than a separate process. This offers a dramatic performance improvement in obtaining the API metadata that the commands rely upon. The new implementation uses `Start-ThreadJob` instead of `Start-Job` to process metadata asynchronously.

### Fixed defects

None.

### Checklist

- [x] All project tests pass successfully