### PR TITLE
Add methods to Get-GraphType

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,7 @@
 
 ## To-do items -- prioritized
 
+* Add New-GraphFilter
 * Add trace-graphrequest / measure-graphrequest commands
 * Add progress for pipeline operations
 * Show-GraphHelp should take a uri

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,8 +21,6 @@
 * Add autocomplete from last items
 * Make setdefaultvalues in new-graphobject take effect
 * Fix directory header inconsistency which used graph qualified paths in some cases, others no graph
-* Add methods to Get-GraphType
-  * $edges = $graph.typevertices['microsoft.graph.user'].outgoingedges; $edges.keys |where { $edgeName = $_; $edge = $edges[$edgeName]; if ( $edge.transition.type -eq 'Action' -or $edge.transition.type -eq 'Function' ) { $true } } | foreach { $edges[$_] }
 * Add method invocation via Invoke-GraphMethod
 * Fix CI on Linux to actually fail when test failures occur
 * Get-GraphType and New-GraphObject should accept both fqn and uqn instead of just uqn for primitive types as for other type classes
@@ -136,7 +134,6 @@
 * set-graphconfig
 * invoke-graphaction
 * generate nuspec
-* Find a better name!
 * README
 * Extended Samples
 * More tests
@@ -339,6 +336,8 @@
 * Set-GraphItem should take an object, not just a hashtable
 * gls and co. should use TypeName instead of FullTypeName, something else other than type
 * Optimize performance for pipeline scenarios for get-graphitem, get-graphchilditem
+* Find a better name! -- We did -- AutoGraph!
+* Add methods to Get-GraphType
 
 ### Postponed
 

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -85,6 +85,7 @@ NestedModules = @(
     'Get-GraphType',
     'Get-GraphUri',
     'Get-GraphUriInfo',
+    'Invoke-GraphMethod',
     'New-Graph',
     'New-GraphItem',
     'New-GraphItemRelationship',
@@ -140,6 +141,7 @@ VariablesToExport = @(
         '.\src\cmdlets\Get-GraphType.ps1',
         '.\src\cmdlets\Get-GraphUri.ps1',
         '.\src\cmdlets\Get-GraphUriInfo.ps1',
+        '.\src\cmdlets\Invoke-GraphMethod.ps1',
         '.\src\cmdlets\New-Graph.ps1',
         '.\src\cmdlets\New-GraphItem.ps1',
         '.\src\cmdlets\New-GraphItemRelationship.ps1',
@@ -230,9 +232,9 @@ None.
 
 ### New features
 
+* New command `Invoke-GraphMethod`: this command issues requests for actions and functions, i.e. *methods* of the Graph API
 * `Get-GraphType` now returns *methods* of types in addition to *properties* and *relationships* (*navigation properties*)
 * `Get-GraphType` has a new `MemberType` parameter to limit the transitive member list to just the specific types (`Property`, `Relationship`, and `Method`) of members.
-
 ### Fixed defects
 
 None.

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.32.0'
+ModuleVersion = '0.33.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -180,7 +180,8 @@ VariablesToExport = @(
         '.\src\metadata\GraphSegment.ps1',
         '.\src\metadata\SegmentParser.ps1',
         '.\src\metadata\QualifiedSchema.ps1',
-        '.\src\metadata\UriCache.ps1'
+        '.\src\metadata\UriCache.ps1',
+        '.\src\typesystem\MethodInfo.ps1',
         '.\src\typesystem\TypeMember.ps1',
         '.\src\typesystem\TypeSchema.ps1',
         '.\src\typesystem\TypeDefinition.ps1',
@@ -215,64 +216,26 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-## AutoGraphPS 0.32.0 Release Notes
+## AutoGraphPS 0.33.0 Release Notes
 
-This release includes major breaking changes in command names, fixes significant defects in type-related functionality, and adds several features to existing commands. Some commands, such as `Get-GraphChildItem`, gain completely new behaviors.
+This release adds functionality for exploring the *methods* of types in addition to their *properties* and *relationships* (*navigation properties*)
 
 ### New dependencies
 
-* AutoGraphPS-SDK 0.21.0
-* Microsoft.Identity.Client (MSAL) 4.14.0
-* Microsoft.IdentityModel.Clients.ActiveDirectory (ADAL) 5.2.7
+None.
 
 ### Breaking changes
 
-* Includes breaking changes from [AutoGraphPS-SDK 0.19.0](https://github.com/adamedx/autographps-sdk/releases/tag/v0.19.0) -- `Get-GraphItem` and `Remove-GraphItem` from `AutoGraphPS-SDK` have been renamed to `Get-GraphResource` and `Remove-GraphResource`
-* `Get-GraphItemWithMetadata` has been renamed to `Get-GraphResourceWithMetadata`
-* `Get-GraphUri` has been renamed to `Get-GraphUriInfo`
-* New implementations of `Get-GraphItem` and `Remove-GraphItem` are introduced in this module -- previously they were part of `AutoGraphPS-SDK` and had different functionality than the new version in this module
+None.
 
 ### New features
-* New commands for write operations, and other commands as well!
-  * `Add-GraphRelatedItem`: creates a new entity in the graph that is associated with an existing entity through a relationship (i.e. an *OData navigation property*)
-  * `Get-GraphRelatedItem`: returns the items related from one entity to a second entity through a relationship property (*OData navigation property*)
-  * `Get-GraphUri`: returns the URI of an entity given the type and id, or for a URI with a relationship
-  * `New-GraphItem`: creates a new item in the graph
-  * `New-GraphItemRelationship`: creates an association from one entity in the graph to a second entity through a relationship property (*OData navigation property*) of the first entity
-  * `New-GraphObject`: creates a deserialized reprsentation of an item in the graph or of data structures referenced in the graph. The representation can be converted to the same JSON format used to serialize data in requests to the graph
-  * `Remove-GraphItemRelatonship`: removes the association from one entity to a second entity
-  * `Set-GraphItem`: updates an existing entity in the graph
-* `Get-GraphType` now supports tab-completion for output, so commands like select can be used interactively when building commands in the shell
-* New `Get-GraphItem` command: a command with this name was in previous versions of the dependency module `AutoGraphPS-SDK`; this new command supports type-aware access of objects by `id` and other type-related facilities.
-* New `Remove-GraphItem` command: a command with this name was in previous versions of the dependency module `AutoGraphPS-SDK`; this new command supports type-aware removal of objects by `id` and other type-related facilities.
-* `Get-Graph` now returns an object with additional fields providing more information about the context of the Graph:
-  * `Id`: The `Id` field is a guid that uniquely identifies the mounted Graph. If the same graph endpoint is mounted again, it will have a different `Id`. The property can be used for cases such as hashing.
-  * `CreationTime`: The time, in the local time zone, at which the graph was mounted
-  * `LastUpdateTime`: The time, in the local time zone, at which the graph was last updated by the `Update-GraphMetadata` command. If no such update occurred, the time is the same as the `CreationTime` property
-  * `LastTypeMetadataSource`: The source of the type metadata used to define the graph when it was first mounted or last updated, which ever is ost recent. The source is either a URI to an http metadata source like https://graph.microsoft.com/v1.0/$metadata or the path to a local file containing the same format of data as that hosted at the http URI.
-* The `ContentColumns` parameter of `Get-GraphChildItem` and `Get-GraphResourceWithMetadata` has been replaced by the `ContentOnly` parameter which has the following behavior: Instead of returning a uniform `PSCustomObject` with standard members including a `Content` member to access the actual content returned by Graph, the command just returns the actual content, just like the `Get-GraphResource` command.
-* The `Get-GraphChildItem` command now also returns children of a type's entityset if applicable
-* The `Get-GraphChildItem`, `Get-GraphItem`, and `Get-GraphResourceWithMetadata` commands now support the following parameters (with parameter-completion where applicable):
-  * Paging parameter support: `First`, `Skip`, `IncludeTotalCount` parameters are now supported (as they are for the `Invoke-GraphRequest` and `Get-GraphResource` commands of `AutoGraphPS-SDK`).
-  * `Expand`: Navigation properties may now be expanded (with parameter completion)
-  * `Search`: For supported entities, an API-defined search query may be specified
-  * `Sort`, `Descending`: Sorting by specified property (with parameter completion) may be specified
-* The `Get-GraphChildItem` and `Get-GraphItem` commands support the `SimpleMatch` parameter that uses a heuristic approach for "casual" graph queries without the need for OData syntax
-* Parameter completion is also supported for the `Expand` and `Sort` commands of `Invoke-GraphRequest` and `Get-GraphResource` when this module is installed.
-* `Show-GraphHelp` supports complex types
-* `Get-GraphType` supports the `TransitiveMembers` parameter and `MemberFilter` parameters
-* Various pipeline improvements have been made to most commands to ensure consistency across commands and enable useful scenarios. In general, pipelines should be easy for the typical PowerShell user to exploit and should adhere to the *Principle of Least Astonishment*.
+
+* `Get-GraphType` now returns *methods* of types in addition to *properties* and *relationships* (*navigation properties*)
+* `Get-GraphType` has a new `MemberType` parameter to limit the transitive member list to just the specific types (`Property`, `Relationship`, and `Method`) of members.
 
 ### Fixed defects
 
-* Graph API versions including `v1.0` and `beta` included multiple namespaces for API metadata after March 2020. Types outside of the `graph.microsoft` namespace were invisible to AutoGraphPS commands -- this has been fixed with support for multiple namespaces.
-* Test execution in CI requires special module-specific logic to rename the AutoGraphPS-SDK modules installed for testing to lower case
-* The `ContentColumns` parameter of `Get-GraphChildItem` and `Get-GraphResourceWithMetadata` has been regressed for several releases due to a syntax error which is now fixed.
-* Inherited properties were absent from objects generated by `New-GraphObject`
-* Inherited properties may be selected for the `Property` argument of `New-GraphObject`
-* Fixed race condition in `Update-GraphMetadata` where some commands like `New-GraphObject` and `Get-GraphType` would not reflect the update
-* Numerous parameter set fixes to `*-GraphItem*` commands including addressing consistency issues with the parameter sets
-* Numerous fixes from commands included from the `AutoGraphPS-SDK` module
+None.
 
 '@
     } # End of PSData hashtable

--- a/autographps.psm1
+++ b/autographps.psm1
@@ -27,6 +27,7 @@ $functions = @(
     'Get-GraphType',
     'Get-GraphUri',
     'Get-GraphUriInfo',
+    'Invoke-GraphMethod',
     'New-Graph',
     'New-GraphObject',
     'New-GraphItem',

--- a/autographps.tests.ps1
+++ b/autographps.tests.ps1
@@ -41,6 +41,7 @@ Describe "Autographps application" {
                 'Get-GraphType'
                 'Get-GraphUri'
                 'Get-GraphUriInfo'
+                'Invoke-GraphMethod'
                 'New-Graph'
                 'New-GraphItem'
                 'New-GraphItemRelationship'

--- a/src/cmdlets.ps1
+++ b/src/cmdlets.ps1
@@ -25,6 +25,7 @@
 . (import-script cmdlets\Get-GraphType)
 . (import-script cmdlets\Get-GraphUri)
 . (import-script cmdlets\Get-GraphUriInfo)
+. (import-script cmdlets\Invoke-GraphMethod)
 . (import-script cmdlets\New-Graph)
 . (import-script cmdlets\Remove-Graph)
 . (import-script cmdlets\Remove-GraphItem)

--- a/src/cmdlets/Invoke-GraphMethod.ps1
+++ b/src/cmdlets/Invoke-GraphMethod.ps1
@@ -1,0 +1,196 @@
+# Copyright 2020, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. (import-script ../typesystem/TypeManager)
+. (import-script common/TypeUriHelper)
+. (import-script common/QueryTranslationHelper)
+. (import-script common/GraphParameterCompleter)
+. (import-script common/TypeParameterCompleter)
+. (import-script common/TypePropertyParameterCompleter)
+. (import-script common/TypeUriParameterCompleter)
+
+function Invoke-GraphMethod {
+    [cmdletbinding(positionalbinding=$false, supportspaging=$true, defaultparametersetname='byobject')]
+    param(
+        [parameter(parametersetname='bytypeandidpipe', valuefrompipelinebypropertyname=$true, mandatory=$true)]
+        [parameter(position=0, parametersetname='bytypeandid', valuefrompipelinebypropertyname=$true, mandatory=$true)]
+        [parameter(position=0, parametersetname='typeandpropertyfilter', mandatory=$true)]
+        [Alias('FullTypeName')]
+        $TypeName,
+
+        [parameter(parametersetname='bytypeandidpipe', valuefrompipelinebypropertyname=$true, mandatory=$true)]
+        [parameter(position=1, parametersetname='bytypeandid', valuefrompipelinebypropertyname=$true, mandatory=$true)]
+        $Id,
+
+        [parameter(position=2, mandatory=$true)]
+        [string] $MethodName,
+
+        [parameter(position=3, parametersetname='bytypeandid')]
+        [parameter(position=3, parametersetname='bytypeandidpipe')]
+        [parameter(position=3, parametersetname='typeandpropertyfilter')]
+        [parameter(position=3, parametersetname='byuri')]
+        [string[]] $Parameter,
+
+        [parameter(position=4, parametersetname='bytypeandid')]
+        [parameter(position=4, parametersetname='bytypeandidpipe')]
+        [parameter(position=4, parametersetname='typeandpropertyfilter')]
+        [parameter(position=4, parametersetname='byuri')]
+        [object[]] $Value,
+
+        [parameter(position=5, parametersetname='bytypeandid')]
+        [parameter(position=5, parametersetname='bytypeandidpipe')]
+        [parameter(position=5, parametersetname='typeandpropertyfilter')]
+        [parameter(position=5, parametersetname='byuri')]
+        [string[]] $Property,
+
+        [HashTable] $ParameterTable,
+
+        [Alias('Body')]
+        [PSCustomObject] $ParameterObject,
+
+        [parameter(parametersetname='byuri', mandatory=$true)]
+        [parameter(parametersetname='byuriandpropertyfilter', mandatory=$true)]
+        [Uri] $Uri,
+
+        [parameter(parametersetname='byobject', valuefrompipeline=$true, mandatory=$true)]
+        [parameter(parametersetname='byobjectandpropertyfilter', valuefrompipeline=$true, mandatory=$true)]
+        [PSCustomObject] $GraphItem,
+
+        [parameter(parametersetname='byuri')]
+        [parameter(parametersetname='byuriandpropertyfilter')]
+        [parameter(parametersetname='bytypeandid')]
+        [parameter(parametersetname='bytypeandidpipe', valuefrompipelinebypropertyname=$true, mandatory=$true)]
+        [parameter(parametersetname='byobject')]
+        [parameter(parametersetname='byobjectandpropertyfilter')]
+        [parameter(parametersetname='typeandpropertyfilter')]
+        $GraphName,
+
+        [parameter(parametersetname='typeandpropertyfilter', mandatory=$true)]
+        [parameter(parametersetname='byuriandpropertyfilter', mandatory=$true)]
+        [parameter(parametersetname='byobjectandpropertyfilter', mandatory=$true)]
+        $PropertyFilter,
+
+        $Filter,
+
+        [Alias('SearchString')]
+        $SimpleMatch,
+
+        [String] $Search,
+
+        [string[]] $Expand,
+
+        [Alias('Sort')]
+        [object[]] $OrderBy = $null,
+
+        [Switch] $Descending,
+
+        [switch] $RawContent,
+
+        [switch] $ChildrenOnly,
+
+        [switch] $FullyQualifiedTypeName,
+
+        [switch] $SkipPropertyCheck
+    )
+
+    begin {
+        Enable-ScriptClassVerbosePreference
+
+        $coreParameters = $null
+
+        if ( $Filter -and $SimpleMatch ) {
+            throw 'Only one of Filter and SimpleMatch arguments may be specified'
+        }
+
+        $filterParameter = @{}
+        $filterValue = $::.QueryTranslationHelper |=> ToFilterParameter $PropertyFilter $Filter
+        if ( $filterValue ) {
+            $filterParameter['Filter'] = $filterValue
+        }
+    }
+
+    process {
+        $targetId = if ( $Id ) {
+            $Id
+        }
+
+        $requestInfo = $::.TypeUriHelper |=> GetTypeAwareRequestInfo $GraphName $TypeName $FullyQualifiedTypeName.IsPresent $Uri $targetId $GraphItem
+
+        if ( ! $SkipPropertyCheck.IsPresent ) {
+            $::.QueryTranslationHelper |=> ValidatePropertyProjection $requestInfo.Context $requestInfo.TypeInfo $Property
+        }
+
+        if ( $requestInfo.IsCollection -and ! $ChildrenOnly.IsPresent -and ( $requestInfo.TypeInfo | gm UriInfo -erroraction ignore ) ) {
+            $requestInfo.TypeInfo.UriInfo
+        } else {
+            $expandArgument = @{}
+            if ( $Expand ) {
+                $expandArgument['Expand'] = $Expand
+            }
+
+            if ( $SimpleMatch ) {
+                $filterParameter['Filter'] = $::.QueryTranslationHelper |=> GetSimpleMatchFilter $requestInfo.Context $requestInfo.TypeName $SimpleMatch
+            }
+
+            $pagingParameters = @{}
+
+            if ( $pscmdlet.pagingparameters.First -ne $null ) { $pagingParameters['First'] = $pscmdlet.pagingparameters.First }
+            if ( $pscmdlet.pagingparameters.Skip -ne $null ) { $pagingParameters['Skip'] = $pscmdlet.pagingparameters.Skip }
+            if ( $pscmdlet.pagingparameters.IncludeTotalCount -ne $null ) { $pagingParameters['IncludeTotalCount'] = $pscmdlet.pagingparameters.IncludeTotalCount }
+
+            $coreParameters = @{
+                Select = $Property
+                Expand = $Expand
+                RawContent = $RawContent
+                OrderBy = $OrderBy
+                Descending = $Descending
+                Search = $Search
+            }
+
+            $methodUri = $requestInfo.Uri.tostring().trimend('/'), $MethodName -join '/'
+            $methodBody = if ( $ParameterObject ) {
+                $ParameterObject
+            } elseif ( $ParameterTable ) {
+                $ParameterTable
+            } elseif ( $Parameter ) {
+                $parameters = @{}
+                $parameterIndex = 0
+                foreach ( $parameterName in $Parameter ) {
+                    $parameters.Add($parameterName, $Value[$parameterIndex])
+                    $parameterIndex++
+                }
+
+                $parameters
+            }
+
+            $bodyParam = if ( $methodBody ) {
+                @{Body=$methodBody}
+            } else {
+                @{}
+            }
+
+            Invoke-GraphRequest -Uri $methodUri -Method POST @bodyParam -Connection $requestInfo.Context.Connection @coreParameters @filterParameter @pagingParameters -erroraction stop
+        }
+    }
+
+    end {
+    }
+}
+
+$::.ParameterCompleter |=> RegisterParameterCompleter Invoke-GraphMethod TypeName (new-so TypeUriParameterCompleter TypeName)
+# $::.ParameterCompleter |=> RegisterParameterCompleter Invoke-GraphMethod OrderBy (new-so TypeUriParameterCompleter Property)
+# $::.ParameterCompleter |=> RegisterParameterCompleter Invoke-GraphMethod Expand (new-so TypeUriParameterCompleter Property $false NavigationProperty)
+# $::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphItem Property (new-so TypeUriParameterCompleter Property $false)
+$::.ParameterCompleter |=> RegisterParameterCompleter Invoke-GraphMethod GraphName (new-so GraphParameterCompleter)
+$::.ParameterCompleter |=> RegisterParameterCompleter Invoke-GraphMethod Uri (new-so GraphUriParameterCompleter ([GraphUriCompletionType]::LocationOrMethodUri ))

--- a/src/cmdlets/common/TypeHelper.ps1
+++ b/src/cmdlets/common/TypeHelper.ps1
@@ -26,9 +26,9 @@ ScriptClass TypeHelper {
             Properties = 'Properties'
             Relationships = 'NavigationProperties'
             IsComposite = 'IsComposite'
+            Methods = 'Methods'
             NativeSchema = 'NativeSchema'
         }
-
 
         function __initialize {
             __RegisterDisplayType
@@ -43,6 +43,7 @@ ScriptClass TypeHelper {
                 Properties = $privateObject.($this.displayProperties.Properties)
                 Relationships = $privateObject.($this.displayProperties.Relationships)
                 IsComposite = $privateObject.($this.displayProperties.IsComposite)
+                Methods = $privateObject.($this.displayProperties.Methods)
                 NativeSchema = $privateObject.($this.displayProperties.NativeSchema)
             }
 
@@ -53,7 +54,7 @@ ScriptClass TypeHelper {
         function __RegisterDisplayType {
             remove-typedata -typename $this.DisplayTypeName -erroraction ignore
 
-            $coreProperties = @('TypeId', 'TypeClass', 'BaseType', 'IsComposite', 'Properties', 'Relationships')
+            $coreProperties = @('TypeId', 'TypeClass', 'BaseType', 'IsComposite', 'Properties', 'Relationships', 'Methods')
 
             $displayTypeArguments = @{
                 TypeName = $this.DisplayTypeName

--- a/src/metadata/EntityGraph.ps1
+++ b/src/metadata/EntityGraph.ps1
@@ -109,6 +109,10 @@ ScriptClass EntityGraph {
         $this.dataModel |=> GetComplexTypes
     }
 
+    function GetMethodsForType($qualifiedTypeName) {
+        $this.dataModel |=> GetMethodBindingsForType $qualifiedTypeName
+    }
+
     function __UpdateVertex($vertex) {
         if ( ! (__IsVertexComplete $vertex) ) {
             $::.ProgressWriter |=> WriteProgress -id 1 -activity "Update vertex '$($vertex.name)'"

--- a/src/typesystem/CompositeTypeProvider.ps1
+++ b/src/typesystem/CompositeTypeProvider.ps1
@@ -58,7 +58,7 @@ ScriptClass CompositeTypeProvider {
             }
         }
 
-        $methodSchemas = GetMethodSchemasForType $typeId
+        $methodSchemas = GetMethodSchemasForType $foundTypeClass $typeId
 
         $methods = if ( $methodSchemas ) {
             foreach ( $methodSchema in $methodSchemas ) {
@@ -111,7 +111,11 @@ ScriptClass CompositeTypeProvider {
         $this.entityTypeTable
     }
 
-    function GetMethodSchemasForType($qualifiedTypeName) {
+    function GetMethodSchemasForType($typeClass, $qualifiedTypeName) {
+        if ( $typeClass -ne 'Entity' ) {
+            return
+        }
+
         $typeVertex = $this.base.graph |=> GetTypeVertex $qualifiedTypeName
         $methodSchemas = $this.base.graph |=> GetMethodsForType $qualifiedTypeName
 

--- a/src/typesystem/MethodInfo.ps1
+++ b/src/typesystem/MethodInfo.ps1
@@ -1,0 +1,55 @@
+# Copyright 2020, Adam Edwards
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ScriptClass MethodInfo {
+    $Name = $null
+    $MethodType = $null
+    $Parameters = $null
+    $ReturnTypeInfo = $null
+
+    function __initialize($graph, $methodBindingSchema, $methodType) {
+        if ( $methodType -eq 'Action' ) {
+            $this.MethodType = 'Action'
+        } elseif ( $methodType -eq 'Function' ) {
+            $this.MethodType = 'Function'
+        } else {
+            throw [ArgumentException]::new("The specified method type '$methodType' is not valid, it must be one of 'Action', 'Function'.")
+        }
+
+        $this.Name = $methodBindingSchema.Name
+
+        $unaliasedReturnType = $null
+        $typeInfo = $null
+
+        if ( ( $methodBindingSchema | gm ReturnType -erroraction ignore ) -and
+             ( $methodBindingSchema.ReturnType | gm Type -erroraction ignore ) ) {
+                 $typeInfo = $::.TypeSchema |=> GetNormalizedPropertyTypeInfo $null $methodBindingSchema.ReturnType.Type
+                 $unaliasedReturnType = $graph |=> UnaliasQualifiedName $typeInfo.TypeFullName
+
+                 $this.ReturnTypeInfo = [PSCustomObject] @{
+                     TypeFullName = $unaliasedReturnType
+                     IsCollection = $typeInfo.IsCollection
+                 }
+             }
+
+        $this.Parameters = @{}
+
+        foreach ( $parameter in $methodBindingSchema.Parameter ) {
+            if ( $parameter.name -ne 'bindingParameter' ) {
+                $unaliasedParameterType = $graph |=> UnaliasQualifiedName $parameter.type
+                $this.Parameters.Add($parameter.name, $unaliasedParameterType)
+            }
+        }
+    }
+}

--- a/src/typesystem/TypeDefinition.ps1
+++ b/src/typesystem/TypeDefinition.ps1
@@ -26,8 +26,9 @@ ScriptClass TypeDefinition {
     $DefaultValue = $null
     $DefaultCollectionValue = $null
     $NativeSchema = $null
+    $Methods = $null
 
-    function __initialize($typeId, [GraphTypeClass] $class, $name, $namespace, $baseType, $properties, $defaultValue, $defaultCollectionValue, $isComposite, $nativeSchema, $navigationProperties) {
+    function __initialize($typeId, [GraphTypeClass] $class, $name, $namespace, $baseType, $properties, $defaultValue, $defaultCollectionValue, $isComposite, $nativeSchema, $navigationProperties, $methods) {
         if ( $class -eq 'Unknown' ) {
             throw [ArgumentException]::new("Error creating definition for type '$typeId': the specified type class 'Unknown' is not valid -- the type must be Enumeration, Complex, Primitive, or Entity")
         }
@@ -38,6 +39,7 @@ ScriptClass TypeDefinition {
         $this.Name = $name
         $this.Properties = @()
         $this.NavigationProperties = @()
+        $this.Methods = @()
         $this.Namespace = $namespace
         $this.IsComposite = $IsComposite
         $this.DefaultValue = $defaultValue
@@ -54,6 +56,10 @@ ScriptClass TypeDefinition {
         if ( $NavigationProperties ) {
             # See the singleton override workaround for the same case above for Properties
             $this.NavigationProperties = if ( ! $navigationProperties -or $navigationProperties.GetType().IsArray ) { $navigationProperties } else { , @($navigationProperties) }
+        }
+
+        if ( $Methods ) {
+            $this.Methods = if ( ! $methods -or $methods.GetType().IsArray ) { $methods } else { , @($methods) }
         }
     }
 }

--- a/src/typesystem/TypeManager.ps1
+++ b/src/typesystem/TypeManager.ps1
@@ -157,6 +157,7 @@ ScriptClass TypeManager {
     enum PropertyType {
         Property
         NavigationProperty
+        Method
     }
 
     function GetTypeDefinitionTransitiveProperties($typeDefinition, $propertyType = 'Property') {
@@ -166,8 +167,10 @@ ScriptClass TypeManager {
 
         $propertyMember = if ( $validatedPropertyType -eq 'NavigationProperty' ) {
             'NavigationProperties'
-        } else {
+        } elseif ( $validatedPropertyType -eq 'Property' ) {
             'Properties'
+        } else {
+            'Methods'
         }
 
         if ( $typeDefinition.$propertyMember ) {

--- a/src/typesystem/TypeMember.ps1
+++ b/src/typesystem/TypeMember.ps1
@@ -15,15 +15,23 @@
 ScriptClass TypeMember {
     $Name = $null
     $TypeId = $null
-    $IsCollection = $null
+    $IsCollection = $false
     $MemberType = $null
+    $MemberData = $null
 
-    function __initialize($name, $typeId, $isCollection, $memberType) {
+    function __initialize($name, $typeId, [bool] $isCollection, $memberType, $memberData) {
         $this.Name = $name
+        $this.MemberData = $memberData
         $this.TypeId = $typeId
         $this.IsCollection = $isCollection
-        $this.MemberType = if ( $memberType -eq $null -or $MemberType -eq 'Property' ) {
+        $this.MemberType = if ( $memberType -eq $null -or $MemberType -in 'Property' ) {
             'Property'
+        } elseif ( $memberType -eq 'Method' ) {
+            if ( $memberData.ReturnTypeInfo ) {
+                $this.TypeId = $memberData.ReturnTypeInfo.TypeFullName
+                $this.IsCollection = $memberData.ReturnTypeInfo.IsCollection
+            }
+            'Method'
         } elseif ( $memberType -eq 'NavigationProperty' ) {
             'Relationship'
         } else {


### PR DESCRIPTION
### Description

Add support to `Get-GraphType` to return the methods of the type.

#### New features

* `Get-GraphType` now returns *methods* of types in addition to *properties* and *relationships* (*navigation properties*)
* `Get-GraphType` has a new `MemberType` parameter to limit the transitive member list to just the specific types (`Property`, `Relationship`, and `Method`) of members.

### Dependency changes

None.

### Checklist

- [ ] All project tests pass successfully