### PR TITLE
Use ThreadJob for background metadata processing

### DIFF
--- a/autographps.psd1
+++ b/autographps.psd1
@@ -69,6 +69,7 @@ FormatsToProcess = @('./src/cmdlets/common/AutoGraphFormats.ps1xml')
 NestedModules = @(
     @{ModuleName='autographps-sdk';ModuleVersion='0.22.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
     @{ModuleName='scriptclass';ModuleVersion='0.20.2';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
+    @{ModuleName='ThreadJob';ModuleVersion='2.0.3';Guid='0e7b895d-2fec-43f7-8cae-11e8d16f6e40'}
 )
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
@@ -230,11 +231,12 @@ PrivateData = @{
         ReleaseNotes = @'
 ## AutoGraphPS 0.33.0 Release Notes
 
-This release adds new commands dedicated to invoking methods (i.e. `OData` *Actions* and *Functions*). There is also new functionality for exploring the *methods* of types in addition to their *properties* and *relationships* (*navigation properties*)
+This release adds new commands dedicated to invoking methods (i.e. `OData` *Actions* and *Functions*). There is also new functionality for exploring the *methods* of types in addition to their *properties* and *relationships* (*navigation properties*). It also adds background metadata processing via ThreadJob rather than PowerShell jobs to optimize performance.
 
 ### New dependencies
 
 * AutoGraphPS-SDK 0.22.0
+* ThreadJob 2.0.3 -- this is the introductory use of ThreadJob for this module
 
 ### Breaking changes
 
@@ -256,6 +258,7 @@ This release adds new commands dedicated to invoking methods (i.e. `OData` *Acti
 * `ShowGraphHelp` has been updated to show help information based on a new `Uri` parameter
 * `ShowGraphHelp` can also take in pipeline input to give help information for an object returned by other commands in this module
 * Commands that return objects from the Graph now return the actual derived type of the object in heterogenous collections that are defined as returning a base type
+* Metadata download and initial processing now uses a thread in the same process hosting AutoGraphPS, rather than a separate process. This offers a dramatic performance improvement in obtaining the API metadata that the commands rely upon. The new implementation uses `Start-ThreadJob` instead of `Start-Job` to process metadata asynchronously.
 
 ### Fixed defects
 

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -244,6 +244,7 @@ This release adds new commands dedicated to invoking methods (i.e. `OData` *Acti
 * The `New-GraphItemRelationship` command now returns output, previously it returned none -- see the `New Features` section for details on the returned output.
 
 ### New features
+
 * New command `Invoke-GraphMethod`: this command issues requests for actions and functions, i.e. *methods* of the Graph API
 * New command `New-GraphMethodParameter`: this command creates objects for the parameters of a given method of an entity
 * New command `Get-GraphItemRelationship`: this command returns the specified relationships from a given object to other objects

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -244,7 +244,6 @@ This release adds new commands dedicated to invoking methods (i.e. `OData` *Acti
 * The `New-GraphItemRelationship` command now returns output, previously it returned none -- see the `New Features` section for details on the returned output.
 
 ### New features
-
 * New command `Invoke-GraphMethod`: this command issues requests for actions and functions, i.e. *methods* of the Graph API
 * New command `New-GraphMethodParameter`: this command creates objects for the parameters of a given method of an entity
 * New command `Get-GraphItemRelationship`: this command returns the specified relationships from a given object to other objects

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,14 +94,14 @@ jobs:
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests'
-    condition: true # eq(variables.OS_PLATFORM, 'windows') # Only on Windows because this hangs on Linux
+    condition: eq(variables.OS_PLATFORM, 'windows') # Only on Windows because this hangs on Linux
     inputs:
       targetType: inline
-      script: si env:TEST_OUTPUT_PATH "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)"; ./build/import-devmodule.ps1 -initialcommand 'Invoke-Pester -OutputFile $env:TEST_OUTPUT_PATH -OutputFormat NUnitXml' -Wait -ReuseConsole:$($PSVersionTable.platform -ne 'unix')
+      script: si env:TEST_OUTPUT_PATH "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)"; ./build/import-devmodule.ps1 -initialcommand 'Invoke-Pester -OutputFile $env:TEST_OUTPUT_PATH -OutputFormat NUnitXml' -Wait -ReuseConsole
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests directly'
-    condition: false # eq(variables.OS_PLATFORM, 'ubuntu') # Only needed on Linux to avoid hangs
+    condition: eq(variables.OS_PLATFORM, 'ubuntu') # Only needed on Linux to avoid hangs
     inputs:
       targetType: inline
       script: './build/Init-DirectTestRun.ps1 -verbose; Invoke-Pester -OutputFile "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)" -OutputFormat NUnitXml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,14 +94,14 @@ jobs:
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests'
-    condition: eq(true, 'windows') # Only on Windows because this hangs on Linux
+    condition: true # eq(variables.OS_PLATFORM, 'windows') # Only on Windows because this hangs on Linux
     inputs:
       targetType: inline
       script: si env:TEST_OUTPUT_PATH "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)"; ./build/import-devmodule.ps1 -initialcommand 'Invoke-Pester -OutputFile $env:TEST_OUTPUT_PATH -OutputFormat NUnitXml' -Wait -ReuseConsole
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests directly'
-    condition: eq(false) # Only needed on Linux to avoid hangs
+    condition: false #eq(variables.OS_PLATFORM, 'ubuntu') # Only needed on Linux to avoid hangs
     inputs:
       targetType: inline
       script: './build/Init-DirectTestRun.ps1 -verbose; Invoke-Pester -OutputFile "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)" -OutputFormat NUnitXml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,14 +94,14 @@ jobs:
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests'
-    condition: eq(variables.OS_PLATFORM, 'windows') # Only on Windows because this hangs on Linux
+    condition: eq(true, 'windows') # Only on Windows because this hangs on Linux
     inputs:
       targetType: inline
       script: si env:TEST_OUTPUT_PATH "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)"; ./build/import-devmodule.ps1 -initialcommand 'Invoke-Pester -OutputFile $env:TEST_OUTPUT_PATH -OutputFormat NUnitXml' -Wait -ReuseConsole
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests directly'
-    condition: eq(variables.OS_PLATFORM, 'ubuntu') # Only needed on Linux to avoid hangs
+    condition: eq(false) # Only needed on Linux to avoid hangs
     inputs:
       targetType: inline
       script: './build/Init-DirectTestRun.ps1 -verbose; Invoke-Pester -OutputFile "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)" -OutputFormat NUnitXml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,11 +97,11 @@ jobs:
     condition: true # eq(variables.OS_PLATFORM, 'windows') # Only on Windows because this hangs on Linux
     inputs:
       targetType: inline
-      script: si env:TEST_OUTPUT_PATH "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)"; ./build/import-devmodule.ps1 -initialcommand 'Invoke-Pester -OutputFile $env:TEST_OUTPUT_PATH -OutputFormat NUnitXml' -Wait -ReuseConsole
+      script: si env:TEST_OUTPUT_PATH "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)"; ./build/import-devmodule.ps1 -initialcommand 'Invoke-Pester -OutputFile $env:TEST_OUTPUT_PATH -OutputFormat NUnitXml' -Wait -ReuseConsole:$($PSVersionTable.platform -ne 'unix')
       pwsh: $(USE_POWERSHELL_CORE)
   - task: powershell@2
     displayName: 'Run tests directly'
-    condition: false #eq(variables.OS_PLATFORM, 'ubuntu') # Only needed on Linux to avoid hangs
+    condition: false # eq(variables.OS_PLATFORM, 'ubuntu') # Only needed on Linux to avoid hangs
     inputs:
       targetType: inline
       script: './build/Init-DirectTestRun.ps1 -verbose; Invoke-Pester -OutputFile "$($env:TEST_OUTPUT_DIRECTORY)/$($env:TEST_OUTPUT_FILE)" -OutputFormat NUnitXml'

--- a/src/metadata/GraphCache.ps1
+++ b/src/metadata/GraphCache.ps1
@@ -175,10 +175,17 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
         write-verbose "Getting async graph for graphid: '$graphId', endpoint: '$endpoint', version: '$apiVersion'"
         write-verbose "Local metadata supplied: '$($metadata -ne $null)'"
 
-        $dependencyModule = 'AutoGraphPS'
-        $thiscode = join-path $psscriptroot '../graph.ps1'
+        $cacheClass = $::.GraphCache
 
-        $graphLoadJob = start-job { param($module, $scriptsourcepath, $graphEndpoint, $version, $schemadata, $verbosity) $verbosepreference=$verbosity; $__poshgraph_no_auto_metadata = $true; import-module $module; . $scriptsourcepath; $::.GraphCache |=> __GetGraph $graphEndpoint $version $schemadata } -argumentlist $dependencymodule, $thiscode, $endpoint, $apiVersion, $metadata, $verbosepreference  -name "AutoGraphPS metadata download for '$graphId'"
+        # Start-ThreadJob starts a ThreadJob, a job running in another thread in this process rather than a separate process. It is much more efficient,
+        # but very strange things occur if ScriptClass method functionality is invoked, possibly because of the way ScriptClass interacts with the call
+        # stack. Due to this, the safest way to pass in ScriptClass state is to pass in an object, and use standard method call syntax rather than
+        # ScriptClass syntax to invoke it. Regardless, Start-ThreadJob is far more efficient than Start-Job AND it doesn't have to serialize and
+        # deserialize objects -- many of the strange workarounds in this module to ensure that ScriptClass object state was preserved is no longer
+        # a necessity, though most of those workarounds are now built in to ScriptClass itself. It may even be feasible to parse the entire graph
+        # rather than only parse just in time since the entire graph can be parsed efficiently in the background without being serialized and deserialized.
+        $graphLoadJob = Start-ThreadJob { param($cacheClass, $graphEndpoint, $version, $schemadata, $verbosity) $verbosepreference=$verbosity; $__poshgraph_no_auto_metadata = $true; $cacheClass.__GetGraph($graphEndpoint, $version, $schemadata) } -argumentlist $cacheClass, $endpoint, $apiVersion, $metadata, $verbosepreference  -name "AutoGraphPS metadata download for '$graphId'"
+>>>>>>> 57491dd... WIP: Initial ThreadJob implementation
 
         $graphAsyncJob = [PSCustomObject]@{Job=$graphLoadJob;Id=$graphId}
         write-verbose "Saving job '$($graphLoadJob.Id) for graphid '$graphId'"

--- a/src/metadata/GraphCache.ps1
+++ b/src/metadata/GraphCache.ps1
@@ -185,7 +185,6 @@ ScriptClass GraphCache -ArgumentList { __Preference__ShowNotReadyMetadataWarning
         # a necessity, though most of those workarounds are now built in to ScriptClass itself. It may even be feasible to parse the entire graph
         # rather than only parse just in time since the entire graph can be parsed efficiently in the background without being serialized and deserialized.
         $graphLoadJob = Start-ThreadJob { param($cacheClass, $graphEndpoint, $version, $schemadata, $verbosity) $verbosepreference=$verbosity; $__poshgraph_no_auto_metadata = $true; $cacheClass.__GetGraph($graphEndpoint, $version, $schemadata) } -argumentlist $cacheClass, $endpoint, $apiVersion, $metadata, $verbosepreference  -name "AutoGraphPS metadata download for '$graphId'"
->>>>>>> 57491dd... WIP: Initial ThreadJob implementation
 
         $graphAsyncJob = [PSCustomObject]@{Job=$graphLoadJob;Id=$graphId}
         write-verbose "Saving job '$($graphLoadJob.Id) for graphid '$graphId'"


### PR DESCRIPTION
### Description

This change introduces the ability to process metadata in the same PowerShell process hosting AutoGraphPS rather than a separate process created through `Start-Job`. In addition to removing process start / stop overhead, performance is improved because objects do not have to be marshalled back to this process, and `scriptclass` does not need to perform additional slow fixups. It is also much easier to debug within the same process, set breakpoints, etc.

### Dependency changes

* ThreadJob 2.0.3 -- this is the introductory use of ThreadJob for this module

### Implementation notes

See the description.

### Checklist

- [ ] All project tests pass successfully
<https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco>
