### PR TITLE
Undo mistaken rename of commands from the previous module version

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ For more details or reference material describing the Graph API URIs, visit the 
 
 #### Access by type
 
-Top-level objects such as `group` or `user` have an `id`. If you know that `id`, you can get information about the actual object using `Get-GraphResourceItem`:
+Top-level objects such as `group` or `user` have an `id`. If you know that `id`, you can get information about the actual object using `Get-GraphItem`:
 
 ```powershell
-Get-GraphResourceItem user -Id f7e9d7b6-f92f-4a78-8537-6b78d874936e
+Get-GraphItem user -Id f7e9d7b6-f92f-4a78-8537-6b78d874936e
 
    Graph Location: /users
 
@@ -94,7 +94,7 @@ Info Type Preview      Id
 ---- ---- -------      --
 t +> user Laquan Smith a57f301b-4fc2-4fac-865c-ee4e1af3084d
 
-Get-GraphResourceItem group -Id a57f301b-4fc2-4fac-865c-ee4e1af3084d
+Get-GraphItem group -Id a57f301b-4fc2-4fac-865c-ee4e1af3084d
 
    Graph Location: /groups
 
@@ -103,7 +103,7 @@ Info Type   Preview        Id
 t +> group  Mathmeticians  57f301b-4fc2-4fac-865c-ee4e1af3084d
 ```
 
-Note that the header of the output gives the hint that you could construct the URI for that type and id combination by appending the `id` as a segment to the URI given by `Graph Location:`. Since `Get-GraphResourceItem` supports a `Uri` parameter, that URI can be specified rather than the type and id parameters. This is the same URI as that used with `Get-GraphResource`, though the output of the two commands is different:
+Note that the header of the output gives the hint that you could construct the URI for that type and id combination by appending the `id` as a segment to the URI given by `Graph Location:`. Since `Get-GraphItem` supports a `Uri` parameter, that URI can be specified rather than the type and id parameters. This is the same URI as that used with `Get-GraphResource`, though the output of the two commands is different:
 
 ```powershell
 Get-GraphResource /users/f7e9d7b6-f92f-4a78-8537-6b78d874936e
@@ -119,16 +119,16 @@ userPrincipalName : laquan@newgriot.edu
 ...
 ```
 
-Note that the output of `Get-GraphResourceItem` is an object that in addition to the protocol response from Graph contains metadata about the response data such as the name of its type, the URI used to access it, a heuristically generated `Preview` field intended for human browsing, etc. The actual API response data exists in the `Content` field and is identical to that returned by the `Get-GraphResource` command. The `-ContentOnly` parameter for `Get-GraphResourceItem` removes the metadata and returns only the response just as with `Get-GraphResource`, eliminating the need to use `Select-Object` or otherwise filter the response to just the `Content`:
+Note that the output of `Get-GraphItem` is an object that in addition to the protocol response from Graph contains metadata about the response data such as the name of its type, the URI used to access it, a heuristically generated `Preview` field intended for human browsing, etc. The actual API response data exists in the `Content` field and is identical to that returned by the `Get-GraphResource` command. The `-ContentOnly` parameter for `Get-GraphItem` removes the metadata and returns only the response just as with `Get-GraphResource`, eliminating the need to use `Select-Object` or otherwise filter the response to just the `Content`:
 
 ```powershell
 # These all have the same output:
-Get-GraphResourceItem /users/f7e9d7b6-f92f-4a78-8537-6b78d874936e | select -ExpandProperty Content
-Get-GraphResourceItem /users/f7e9d7b6-f92f-4a78-8537-6b78d874936e -ContentOnly
+Get-GraphItem /users/f7e9d7b6-f92f-4a78-8537-6b78d874936e | select -ExpandProperty Content
+Get-GraphItem /users/f7e9d7b6-f92f-4a78-8537-6b78d874936e -ContentOnly
 Get-GraphResource /users/f7e9d7b6-f92f-4a78-8537-6b78d874936e
 ```
 
-There is also a related command, `Get-GraphChildItem` that enables the enumeration of multiple objects and relates to `Get-GraphResourceItem` in a fashion similar to the relationship between the standard `Get-ChildItem` and `Get-Item` commands of PowerShell.
+There is also a related command, `Get-GraphChildItem` that enables the enumeration of multiple objects and relates to `Get-GraphItem` in a fashion similar to the relationship between the standard `Get-ChildItem` and `Get-Item` commands of PowerShell.
 
 ### More fun commands
 
@@ -187,14 +187,14 @@ t +> driveItem Pyramid.js    13J3KD2
 
 #### Don't forget write operations
 
-Yes, you can perform write-operations! Commands like `New-GraphResourceItem`, `Set-GraphResourceItem`, and `Remove-GraphResourceItem` allow you to make changes to data in the Graph.
+Yes, you can perform write-operations! Commands like `New-GraphItem`, `Set-GraphItem`, and `Remove-GraphItem` allow you to make changes to data in the Graph.
 
-#### Create a new item with New-GraphResourceItem
+#### Create a new item with New-GraphItem
 
-The `New-GraphResourceItem` command creates new entities in the Graph. The example below creates a new security group:
+The `New-GraphItem` command creates new entities in the Graph. The example below creates a new security group:
 
 ```powershell
-New-GraphResourceItem group -Property mailNickName, displayName, mailEnabled, securityEnabled -Value blackgold, 'Black Gold', $false, $true
+New-GraphItem group -Property mailNickName, displayName, mailEnabled, securityEnabled -Value blackgold, 'Black Gold', $false, $true
 
 description                   :
 mailNickname                  : blackgold
@@ -204,20 +204,20 @@ displayName                   : Black Gold
 ...
 ```
 
-##### Update an item with Set-GraphResourceItem
+##### Update an item with Set-GraphItem
 
-The `Set-GraphResourceItem` command lets you change the properties of an existing item:
+The `Set-GraphItem` command lets you change the properties of an existing item:
 
 ```powershell
-$newGroup | Set-GraphResourceItem -Property displayName, description -Value 'Black Gold Team', 'Collaboration for the Black Gold Gala event'
-$newGroup | Get-GraphResourceItem -ContentOnly | select displayName, description
+$newGroup | Set-GraphItem -Property displayName, description -Value 'Black Gold Team', 'Collaboration for the Black Gold Gala event'
+$newGroup | Get-GraphItem -ContentOnly | select displayName, description
 
 displayName     description
 -----------     -----------
 Black Gold Team Collaboration for the Black Gold Gala event
 ```
 
-In this case, the `displayName` and `description` properties of the newly created group are updated to new values when `Set-GraphResourceItem` is executed. A subsequent invocation of `Get-GraphResourceItem` to request the current version of the object from Graph reflects the updates made to those properties.
+In this case, the `displayName` and `description` properties of the newly created group are updated to new values when `Set-GraphItem` is executed. A subsequent invocation of `Get-GraphItem` to request the current version of the object from Graph reflects the updates made to those properties.
 
 ##### New-GraphObject makes write operations easier
 
@@ -228,31 +228,31 @@ For example, if you know the name of the type of object, say `contact`, and you 
 ```powershell
 $emailAddress = New-GraphObject emailAddress -Property name, address -value Work, cleo@soulsonic.org
 $contactData = New-GraphObject contact -Property givenName, emailAddresses -value 'Cleopatra Jones', @($emailAddress)
-$newContact = $contactData | New-GraphResourceItem -Uri me/contacts
+$newContact = $contactData | New-GraphItem -Uri me/contacts
 ```
 
-##### Clean up with Remove-GraphResourceItem
+##### Clean up with Remove-GraphItem
 
-The `Remove-GraphResourceItem` command deletes an entity from the Graph -- it is the inverse of `New-GraphResourceItem`. It includes a set of parameters that allows for the specifiation of the type and the id of the entity to remove and also provides the option to specify the entity's URI. And if you already have an instance of the object available as we do from the above example, you can just pipe the instance to delete to `Remove-GraphResourceItem`:
+The `Remove-GraphItem` command deletes an entity from the Graph -- it is the inverse of `New-GraphItem`. It includes a set of parameters that allows for the specifiation of the type and the id of the entity to remove and also provides the option to specify the entity's URI. And if you already have an instance of the object available as we do from the above example, you can just pipe the instance to delete to `Remove-GraphItem`:
 
 ```powershell
-$newContact | Remove-GraphResourceItem
+$newContact | Remove-GraphItem
 ```
 
-Subsequent attempts to retrieve the entity from the Graph by identifier or URI using commands such as `Get-GraphResourceItem` or `Get-GraphResource` will fail because the entity has been deleted by `Remove-GraphResourceItem`.
+Subsequent attempts to retrieve the entity from the Graph by identifier or URI using commands such as `Get-GraphItem` or `Get-GraphResource` will fail because the entity has been deleted by `Remove-GraphItem`.
 
 ##### Invoke-GraphRequest handles all the REST
 
 What if you can't find exactly the command you need to interact with the Graph? The `Invoke-GraphRequest` is a general-purpose command that, with the right parameters, can emulate any of the other commands that interact with Graph. It is a generic REST client capable of issuing any valid request to the Graph. You can use it if you run into a scenario that isn't covered by the other commmands. In general it may be useful if you're already using REST to interact with the Graph.
 
-Here's one example that issues the same request as in the earlier example for `New-GraphResourceItem':
+Here's one example that issues the same request as in the earlier example for `New-GraphItem':
 
 ```powershell
 $contactData = @{givenName='Cleopatra Jones';emailAddresses=@(@{name='Work';Address='cleo@soulsonic.org'})}
 Invoke-GraphRequest -Method POST me/contacts -Body $contactData
 ```
 
-As its name suggests, the `Method` parameter of `Invoke-GraphRequest` lets you specify any **REST** method, i.e. `PUT`, `POST`, `PATCH`, and `DELETE`. Thus `Invoke-GraphRequest` is capable of executing any capability of Graph and can be considered *the universal Graph command.* The example given here is less readable than the `New-GraphObject` / `New-GraphResourceItem` example and requires you to know more about the underlying Graph protocol (e.g that creation of data usually means you must use the `POST` method), but it is consistent with the idea that if you can't find the command you need, you can always find a way to get things working with `Invoke-GraphRequest`, even if it trades off simplicity.
+As its name suggests, the `Method` parameter of `Invoke-GraphRequest` lets you specify any **REST** method, i.e. `PUT`, `POST`, `PATCH`, and `DELETE`. Thus `Invoke-GraphRequest` is capable of executing any capability of Graph and can be considered *the universal Graph command.* The example given here is less readable than the `New-GraphObject` / `New-GraphItem` example and requires you to know more about the underlying Graph protocol (e.g that creation of data usually means you must use the `POST` method), but it is consistent with the idea that if you can't find the command you need, you can always find a way to get things working with `Invoke-GraphRequest`, even if it trades off simplicity.
 
 Note that the `Body` parameter allows you to specify the JSON body of the request which typically describes the information to write. In the example above, rather than specify the JSON directly, we chose to express it as a PowerShell `HashTable` object. When the `Body` parameter is not a JSON string, `Invoke-GraphRequest` converts whatever type you specify to JSON for you. The way the `HashTable` was structured in this example allowed it to be serialized into exactly the JSON format required to `POST` a `contact` object to `/me/contacts` as a well-formed request.
 
@@ -335,7 +335,7 @@ Note that since AutoGraphPS is built on [AutoGraphPS-SDK](https://github.com/ada
 | Get-GraphChildItem (ggci) | Retrieves in tabular format the list of entities for a given Uri AND child segments of the Uri          |
 | Get-GraphConnectionInfo   | Gets information about a connection to a Graph endpoint, including identity and  `Online` or `Offline` |
 | Get-GraphError (gge)      | Retrieves detailed errors returned from Graph in execution of the last command                          |
-| Get-GraphResourceItem     | Retrieves an entity specified by type and ID or URI |
+| Get-GraphItem     | Retrieves an entity specified by type and ID or URI |
 | Get-GraphResource (ggr)   | Given a relative (to the Graph or current location) Uri gets information about the entity               |
 | Get-GraphResourceWithMetadata (gls) | Retrieves in tabular format the list of entities and metadata for a given Uri                     |
 | Get-GraphLocation (gwd)   | Retrieves the current location in the Uri hierarchy for the current graph                               |
@@ -352,17 +352,17 @@ Note that since AutoGraphPS is built on [AutoGraphPS-SDK](https://github.com/ada
 | New-GraphConnection       | Creates an authenticated connection using advanced identity customizations for accessing a Graph        |
 | New-GraphMethodParameter  | Creates a local representation of a Graph type for the specified parameter of a specified Graph method  |
 | New-GraphObject           | Creates a local representation of a type defined by the Graph API that can be specified in the body of write requests in commands such as `Invoke-GraphRequest` |
-| New-GraphResourceItem     | Creates an instance of the specified entity type in the Graph given a set of properties |
+| New-GraphItem     | Creates an instance of the specified entity type in the Graph given a set of properties |
 | Register-GraphApplication | Creates a registration in the tenant for an existing Azure AD application    |
 | Remove-Graph              | Unmounts a Graph previously mounted by `NewGraph`                                                       |
 | Remove-GraphApplication   | Deletes an Azure AD application                                                                         |
 | Remove-GraphApplicationCertificate | Removes a public key from the application for a certificate allowed to authenticate as that application |
 | Remove-GraphApplicationConsent | Removes consent grants for an Azure AD application                                                 |
-| Remove-GraphResourceItem  | Removes an entity specified by type and ID or URI |
+| Remove-GraphItem  | Removes an entity specified by type and ID or URI |
 | Remove-GraphResource                 | Makes generic ``DELETE`` requests to a specified Graph URI to delete resources                      |
 | Set-GraphApplicationConsent       | Sets a consent grant for an Azure AD application                                                |
 | Set-GraphConnectionStatus | Configures `Offline` mode for use with local commands like `GetGraphUri` or re-enables `Online` mode for accessing the Graph service |
-| Set-GraphResourceItem     | Updates properties of a given Graph entity with the specified values |
+| Set-GraphItem     | Updates properties of a given Graph entity with the specified values |
 | Set-GraphLocation (gcd)   | Sets the current graph and location in the graph's Uri hierarchy; analog to `cd` / `set-location` cmdlet for PowerShell when working with file systems |
 | Set-GraphLogOption        | Sets the configuration options for logging of requests to Graph including options that control the detail level of the data logged |
 | Set-GraphPrompt           | Adds connection and location context to the PowerShell prompt or disables it                            |
@@ -454,4 +454,5 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -77,11 +77,11 @@ NestedModules = @(
     'Add-GraphRelatedItem',
     'Find-GraphPermission',
     'Get-Graph',
-    'Get-GraphResourceChildItem',
-    'Get-GraphResourceItem',
+    'Get-GraphChildItem',
+    'Get-GraphItem',
     'Get-GraphItemRelationship',
     'Get-GraphRelatedItem',
-    'Get-GraphResourceItemUri',
+    'Get-GraphItemUri',
     'Get-GraphResourceWithMetadata',
     'Get-GraphLocation',
     'Get-GraphType',
@@ -89,14 +89,14 @@ NestedModules = @(
     'Get-GraphUriInfo',
     'Invoke-GraphMethod',
     'New-Graph',
-    'New-GraphResourceItem',
+    'New-GraphItem',
     'New-GraphItemRelationship',
     'New-GraphMethodParameterObject',
     'New-GraphObject',
     'Remove-Graph',
-    'Remove-GraphResourceItem',
+    'Remove-GraphItem',
     'Remove-GraphItemRelationship',
-    'Set-GraphResourceItem',
+    'Set-GraphItem',
     'Set-GraphLocation',
     'Set-GraphPrompt',
     'Show-GraphHelp',
@@ -135,10 +135,10 @@ VariablesToExport = @(
         '.\src\cmdlets\Add-GraphRelatedItem.ps1',
         '.\src\cmdlets\Find-GraphPermission.ps1',
         '.\src\cmdlets\Get-Graph.ps1',
-        '.\src\cmdlets\Get-GraphResourceChildItem.ps1',
-        '.\src\cmdlets\Get-GraphResourceItem.ps1',
+        '.\src\cmdlets\Get-GraphChildItem.ps1',
+        '.\src\cmdlets\Get-GraphItem.ps1',
         '.\src\cmdlets\Get-GraphItemRelationship.ps1',
-        '.\src\cmdlets\Get-GraphResourceItemUri.ps1',
+        '.\src\cmdlets\Get-GraphItemUri.ps1',
         '.\src\cmdlets\Get-GraphLocation.ps1',
         '.\src\cmdlets\Get-GraphRelatedItem.ps1',
         '.\src\cmdlets\Get-GraphResourceWithMetadata.ps1',
@@ -147,14 +147,14 @@ VariablesToExport = @(
         '.\src\cmdlets\Get-GraphUriInfo.ps1',
         '.\src\cmdlets\Invoke-GraphMethod.ps1',
         '.\src\cmdlets\New-Graph.ps1',
-        '.\src\cmdlets\New-GraphResourceItem.ps1',
+        '.\src\cmdlets\New-GraphItem.ps1',
         '.\src\cmdlets\New-GraphItemRelationship.ps1',
         '.\src\cmdlets\New-GraphMethodParameterObject.ps1',
         '.\src\cmdlets\New-GraphObject.ps1',
         '.\src\cmdlets\Remove-Graph.ps1',
-        '.\src\cmdlets\Remove-GraphResourceItem.ps1',
+        '.\src\cmdlets\Remove-GraphItem.ps1',
         '.\src\cmdlets\Remove-GraphItemRelationship.ps1',
-        '.\src\cmdlets\Set-GraphResourceItem.ps1',
+        '.\src\cmdlets\Set-GraphItem.ps1',
         '.\src\cmdlets\Set-GraphLocation.ps1',
         '.\src\cmdlets\Set-GraphPrompt.ps1',
         '.\src\cmdlets\Show-GraphHelp.ps1',
@@ -239,6 +239,14 @@ Fixes command name conflict with AutoGraphPS-SDK dependency for the `Remove-Grap
 
 ### Breaking changes
 
+* The following commands are renamed back to what they were prior to an incorrect rename in the version of this module (0.33.0) prior to this one:
+  Get-GraphResourceChildItem -> Get-GraphChildItem
+  Get-GraphResourceItem -> Get-GraphItem
+  Get-GraphResourceItemUri -> Get-GraphItemUri
+  New-GraphResourceItem -> New-GraphItem
+  Remove-GraphResourceItem -> Remove-GraphItem
+  Set-GraphResourceItem -> Set-GraphItem
+
 None.
 
 ### New features
@@ -261,3 +269,5 @@ None.
 # DefaultCommandPrefix = ''
 
 }
+
+

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -12,7 +12,7 @@
 RootModule = 'autographps.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.34.0'
+ModuleVersion = '0.35.0'
 
 # Supported PSEditions
 CompatiblePSEditions = @('Desktop', 'Core')
@@ -67,7 +67,7 @@ FormatsToProcess = @('./src/cmdlets/common/AutoGraphFormats.ps1xml')
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='autographps-sdk';ModuleVersion='0.23.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='autographps-sdk';ModuleVersion='0.24.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
     @{ModuleName='scriptclass';ModuleVersion='0.20.2';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
     @{ModuleName='ThreadJob';ModuleVersion='2.0.3';Guid='0e7b895d-2fec-43f7-8cae-11e8d16f6e40'}
 )
@@ -229,13 +229,13 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-## AutoGraphPS 0.34.0 Release Notes
+## AutoGraphPS 0.35.0 Release Notes
 
-Bug fixes and minor usability improvements
+Fixes command name conflict with AutoGraphPS-SDK dependency for the `Remove-GraphItem` command, and undoes the renaming of several commands in this module incorrectly undertaken when the `Remove-GraphItem` conflict was misunderstood to be due to community usage rather than a defect in a dependency.
 
 ### New dependencies
 
-None.
+* AutoGraphPS-SDK 0.24.0
 
 ### Breaking changes
 
@@ -243,27 +243,11 @@ None.
 
 ### New features
 
-* Progress UX now uses the built-in PowerShell progress output mechanism rather than a custom mechanism
-* New aliases have been introduced for common commands:
-  `gcd -> Set-GraphLocation`
-  `gg -> Get-Graph`
-  `ggrel -> Get-GraphItemRelationship`
-  `ggreli -> Get-GraphRelatedItem`
-  `ggu -> Get-GraphUriInfo`
-  `ggci -> Get-GraphResourceChildItem`
-  `ggi -> Get-GraphResourceItem`
-  `gls -> Get-GraphResourceWithMetadata`
-  `gwd -> Get-GraphLocation`
-  `gni -> New-GraphResourceItem`
-  `grm -> Remove-GraphResourceItem`
-  `gsi -> Set-GraphResourceItem`
-  `igm -> Invoke-GraphMethod`
-  `ngo -> New-GraphObject`
-  `ngp -> New-GraphMethodParameterObject`
+None.
 
 ### Fixed defects
 
-* The `Get-GraphResourceChildItem` command was inaccessible due to a regression from the command name changes in the previous release -- this has been fixed
+* At installation time the module would complain of a conflict with `Remove-GraphItem` which is exposed by this module. It turns out that while an earlier version of `AutoGraphPS-SDK` had exported an identically-named command but had renamed it to `Remove-GraphResource`, the rename process was incomplete and `AutoGraphPS-SDK` was still exporting this command. The fix for this module is to include an updated version of `AutoGraphPS-SDK` that no longer exports `Remove-GraphItem` and does export `Remove-GraphResource`.
 
 '@
     } # End of PSData hashtable

--- a/autographps.psm1
+++ b/autographps.psm1
@@ -18,11 +18,11 @@ $functions = @(
     'Add-GraphRelatedItem',
     'Find-GraphPermission',
     'Get-Graph',
-    'Get-GraphResourceItem',
+    'Get-GraphItem',
     'Get-GraphItemRelationship',
     'Get-GraphRelatedItem',
-    'Get-GraphResourceItemUri',
-    'Get-GraphResourceChildItem',
+    'Get-GraphItemUri',
+    'Get-GraphChildItem',
     'Get-GraphResourceWithMetadata',
     'Get-GraphLocation',
     'Get-GraphType',
@@ -30,14 +30,14 @@ $functions = @(
     'Get-GraphUriInfo',
     'Invoke-GraphMethod',
     'New-Graph',
-    'New-GraphResourceItem',
+    'New-GraphItem',
     'New-GraphItemRelationship',
     'New-GraphMethodParameterObject',
     'New-GraphObject',
     'Remove-Graph',
-    'Remove-GraphResourceItem',
+    'Remove-GraphItem',
     'Remove-GraphItemRelationship',
-    'Set-GraphResourceItem',
+    'Set-GraphItem',
     'Set-GraphLocation',
     'Set-GraphPrompt',
     'Show-GraphHelp',
@@ -59,3 +59,5 @@ $variables = @(
 )
 
 export-modulemember -function $functions -alias $aliases -variable $variables
+
+

--- a/autographps.tests.ps1
+++ b/autographps.tests.ps1
@@ -32,11 +32,11 @@ Describe "Autographps application" {
                 'Add-GraphRelatedItem'
                 'Find-GraphPermission'
                 'Get-Graph'
-                'Get-GraphResourceChildItem'
-                'Get-GraphResourceItem'
+                'Get-GraphChildItem'
+                'Get-GraphItem'
                 'Get-GraphItemRelationship'
                 'Get-GraphRelatedItem'
-                'Get-GraphResourceItemUri'
+                'Get-GraphItemUri'
                 'Get-GraphResourceWithMetadata'
                 'Get-GraphLocation'
                 'Get-GraphType'
@@ -44,14 +44,14 @@ Describe "Autographps application" {
                 'Get-GraphUriInfo'
                 'Invoke-GraphMethod'
                 'New-Graph'
-                'New-GraphResourceItem'
+                'New-GraphItem'
                 'New-GraphItemRelationship'
                 'New-GraphMethodParameterObject'
                 'New-GraphObject'
                 'Remove-Graph'
-                'Remove-GraphResourceItem'
+                'Remove-GraphItem'
                 'Remove-GraphItemRelationship'
-                'Set-GraphResourceItem',
+                'Set-GraphItem',
                 'Set-GraphLocation'
                 'Set-GraphPrompt'
                 'Show-GraphHelp'
@@ -95,5 +95,7 @@ Describe "Autographps application" {
         }
     }
 }
+
+
 
 

--- a/docs/WALKTHROUGH.md
+++ b/docs/WALKTHROUGH.md
@@ -328,11 +328,11 @@ The `$false` assignment in the hash table means that the field will use *ascendi
 
 AutoGraphPS isn't just an excellent browsing experience, it features commands for modifying the Graph as well:
 
-* `New-GraphResourceItem`
-* `Set-GraphResourceItem`
+* `New-GraphItem`
+* `Set-GraphItem`
 * `New-GraphObject`
 * `New-GraphItemRelationship`
-* `Remove-GraphResourceItem`
+* `Remove-GraphItem`
 
 The following examples demonstrate common usage of these commands in creating and editing Graph resources. Unlike the read-only cases we've explored so far, you're likely to need some light research before jumping in with these command, i.e. you might want to read the actual Graph API documentation first. In particular, you'll need to have some basic answers in mind for the following questions before using write-operation commands:
 
@@ -359,7 +359,7 @@ Lastly, while in many cases the property values are simple "primitive" types lik
 $ipRange = New-GraphObject ipv6Range
 ```
 
-You can then set the properties of the `$ipRange` variable as desired, and specify that variable as one of the property values to `New-GraphResourceItem` or `Set-GraphResourceItem`.
+You can then set the properties of the `$ipRange` variable as desired, and specify that variable as one of the property values to `New-GraphItem` or `Set-GraphItem`.
 
 Now this preamble may seem rather lengthy compared to our near zero-knowledge approach of read-only use cases, but all of this really boils down to the need to know what you're going to change before you make an update, which isn't unreasonable for these more "dangerous" write use-cases. Fortunately, the answers to all of those questions are a few tab-completions or `Get-GraphType` / `Show-GraphHelp` invocations away.
 
@@ -380,13 +380,13 @@ A few notes are in order:
 
 #### Create a simple resource: group (AAD accounts only)
 
-This example uses the `New-GraphResourceItem` command to creates a new AAD security group:
+This example uses the `New-GraphItem` command to creates a new AAD security group:
 
 ```powershell
-PS> $newGroup = New-GraphResourceItem group -Property mailNickName, displayName, mailEnabled, securityEnabled -Value Group7Access, 'Group 7 Access', $false, $true
+PS> $newGroup = New-GraphItem group -Property mailNickName, displayName, mailEnabled, securityEnabled -Value Group7Access, 'Group 7 Access', $false, $true
 ```
 
-The example specifies the following parameters for `New-GraphResourceItem`:
+The example specifies the following parameters for `New-GraphItem`:
 * The first (unnamed) parameter `group` specifies that the type of the resource to create is `group`
 * The `Property` parameter specifies the properties that must be set for the new resource
 * The `Value` parameter specifies the values to which those properties must be set
@@ -405,18 +405,18 @@ createdDateTime      displayName    mailNickname
 2020-04-22T01:27:41Z Group 7 Access Group7Access
 ```
 
-The example specifies the following parameters for `New-GraphResourceItem`:
+The example specifies the following parameters for `New-GraphItem`:
 * The first (unnamed) parameter `group` specifies that the type of the resource to create is `group`
 * The `Property` parameter specifies the properties that must be set for the new resource
 * The `Value` parameter specifies the values to which those properties must be set
 
-Additionally, following the invocation of `New-GraphResourceItem` that creates the new security group, the example assigns the result of the creation to the variable `$newGroup`, and then outputs 3 columns of the variable to the console for inspection.
+Additionally, following the invocation of `New-GraphItem` that creates the new security group, the example assigns the result of the creation to the variable `$newGroup`, and then outputs 3 columns of the variable to the console for inspection.
 
 #### Create a resource with nested data: user
 
 Creating a group was easy. Let's create a user. Before doing so, a quick consultation of the user resource's documentation via `Show-GraphHelp user` indicates that we need to specify the following properties at creation time: `mailNickName`, `userPrincipalName`, `displayName`, `accountEnabled`, and `passwordProfile`. The first four are simple types (`string`, `string`, `string`, and `bool` respectively) that we know how to specify via command line arguments, but according to the documentation (and also `Get-GraphType user`), the last is of type `passswordProfile`, how do we specify that?
 
-We can use the `New-GraphObject` command to create the data structures as PowerShell objects (or optionally as `JSON` text). `New-GraphObject` does not issue requests or otherwise interact with Graph, but the local objects it creates can be can be specified to commands like `New-GraphResourceItem`, `Set-GraphResourceItem`, etc., that must submit such objects in requests. The parameters of `New-GraphObject` have similar naming and semantics to thsoe of `New-GraphResourceItem` when it comes to types and properties, so after consulting the documentation for `passwordProfile` we see that we can create the `passwordProfile` object with this command:
+We can use the `New-GraphObject` command to create the data structures as PowerShell objects (or optionally as `JSON` text). `New-GraphObject` does not issue requests or otherwise interact with Graph, but the local objects it creates can be can be specified to commands like `New-GraphItem`, `Set-GraphItem`, etc., that must submit such objects in requests. The parameters of `New-GraphObject` have similar naming and semantics to thsoe of `New-GraphItem` when it comes to types and properties, so after consulting the documentation for `passwordProfile` we see that we can create the `passwordProfile` object with this command:
 
 ```powershell
 $passwordProfile = New-GraphObject passwordprofile -Property forceChangePasswordNextSignIn, password -value $true, (Get-Credential user).GetNetworkCredential().Password
@@ -428,13 +428,13 @@ Now we're ready to actually make the request to Graph that creates the user:
 
 ```powershell
 # This assumes you set `$passwordProfile` using the earlier `New-GraphObject` example
-$newUser = New-GraphResourceItem user -Property mailNickname, userPrincipalName, displayname, accountEnabled, passwordProfile -Value treejack, treejack@newnoir.org, 'Treemonisha Jackson', $true, $passwordProfile
+$newUser = New-GraphItem user -Property mailNickname, userPrincipalName, displayname, accountEnabled, passwordProfile -Value treejack, treejack@newnoir.org, 'Treemonisha Jackson', $true, $passwordProfile
 ```
 
 We can see that the user has been successfully created by issuing a request to the Graph to get the new user using a command like the following:
 
 ```powershell
-PS> Get-GraphResourceItem user -Id $newUser.Id
+PS> Get-GraphItem user -Id $newUser.Id
 
    Graph Location: /users
 
@@ -448,19 +448,19 @@ t +> user Treemonisha Jackson 8618a75d-a209-44f3-b2f8-2423cb211eed
 In this example, a new `contact` (i.e. e-mail or phone contact; requires either a free Microsoft account or non-trial AAD subscription) for the signed-in user is created. Here's a first attempt:
 
 ```powershell
-PS> $newContact = New-GraphResourceItem contact
+PS> $newContact = New-GraphItem contact
 
 foreach : Exception calling "InvokeMethod" with "2" argument(s): "Unable to find URI for type 'contact' -- explicitly specify the target URI and retry."
 ```
 
-Unfortunately, that didn't work. The exception and resulting error message indicating we should *specify the target URI and retry* means that `New-GraphResourceItem` could not translate our request to create a contact to a REST URI for Graph. Unlike the user case, there is no well-known request URI at which to create a contact (for `user` it is a URI like `https://graph.microsoft.com/v1.0/users`) because *`contact` is the type of object that exists only in relation to another object, not as a standalone instance*.
+Unfortunately, that didn't work. The exception and resulting error message indicating we should *specify the target URI and retry* means that `New-GraphItem` could not translate our request to create a contact to a REST URI for Graph. Unlike the user case, there is no well-known request URI at which to create a contact (for `user` it is a URI like `https://graph.microsoft.com/v1.0/users`) because *`contact` is the type of object that exists only in relation to another object, not as a standalone instance*.
 
-Actually reviewing the REST documentation for contact shows that the use case for creating a contact is accomplished via `POST` to the resource URI `https://graph.microsoft.com/v1.0/me/contacts`. Conveniently, `New-GraphResourceItem` supports a `Uri` parameter that allows you to specify the URI (`me` since AutoGraphPS commands abstract the earlier parts of the URI), so after searching for additional documentation about `contact` and experimenting to make up for the fact that as of this writing the documentation lacks details about which properties are required at creation time, we can execute the following commands to create a `contact`:
+Actually reviewing the REST documentation for contact shows that the use case for creating a contact is accomplished via `POST` to the resource URI `https://graph.microsoft.com/v1.0/me/contacts`. Conveniently, `New-GraphItem` supports a `Uri` parameter that allows you to specify the URI (`me` since AutoGraphPS commands abstract the earlier parts of the URI), so after searching for additional documentation about `contact` and experimenting to make up for the fact that as of this writing the documentation lacks details about which properties are required at creation time, we can execute the following commands to create a `contact`:
 
 ```powershell
 # Create the emailAddress object that is required at creation time as an array
 $emailAddress = New-GraphObject emailAddress -Property name, address -Value Work, cleo@soulsonic.org
-$newContact = New-GraphResourceItem -uri /me/contacts -Property givenName, emailAddresses -Value 'Cleopatra Jones', @($emailAddress)
+$newContact = New-GraphItem -uri /me/contacts -Property givenName, emailAddresses -Value 'Cleopatra Jones', @($emailAddress)
 
 # Dump the returned item to the console
 PS> $newContact | select createdDateTime, displayname, emailAddresses
@@ -480,29 +480,29 @@ which will issue a request to Graph to retrieve all contacts, and then filter th
 
 #### Update an existing resource: contact, group, and user
 
-To modify an existing Graph resource, use the `Set-GraphResourceItem` command. You can pipe in the result of a previous `Get-GraphResourceItem`, `Get-GraphResource`, `New-GraphResourceItem`, etc., invocation as the object to modify:
+To modify an existing Graph resource, use the `Set-GraphItem` command. You can pipe in the result of a previous `Get-GraphItem`, `Get-GraphResource`, `New-GraphItem`, etc., invocation as the object to modify:
 
 ```powershell
-$newGroup | Set-GraphResourceItem -Property displayName, description -Value 'Group 7 Access Level', 'All users with Group 7 access'
+$newGroup | Set-GraphItem -Property displayName, description -Value 'Group 7 Access Level', 'All users with Group 7 access'
 ```
 
-This changes the group's display name to *Group 7 Access Level* and updates the description as well. This example takes the object to modify from the pipeline. Since this command has analogs of parameters from `New-GraphResourceItem` and `New-GraphObject`, you can also specify commands using the following syntax:
+This changes the group's display name to *Group 7 Access Level* and updates the description as well. This example takes the object to modify from the pipeline. Since this command has analogs of parameters from `New-GraphItem` and `New-GraphObject`, you can also specify commands using the following syntax:
 
 ```powershell
-Set-GraphResourceItem group -Id $newGroup.Id -Property displayName, description -Value 'Group 7 Access Level', 'All users with Group 7 access'
+Set-GraphItem group -Id $newGroup.Id -Property displayName, description -Value 'Group 7 Access Level', 'All users with Group 7 access'
 ```
 
 And there are still more equivalent syntaxes, using the `PropertyTable` or `TemplateObject` parameters. `PropertyTable` is just a more concise way to specify the `Property` and `Value` parameters via a `HashTable`:
 
 ```powershell
-$newGroup | Set-GraphResourceItem -PropertyTable @{displayName='Group 7 Access Level'; description='All users with Group 7 access'}
+$newGroup | Set-GraphItem -PropertyTable @{displayName='Group 7 Access Level'; description='All users with Group 7 access'}
 ```
 
 The `TeamplateObject` parameter allows the these properties and values to be specified in the form of an object, such as one returned by `New-GraphObject` or even from the Graph itself via `Get-GraphResource` or `gls`:
 
 ```powershell
 $modifiedGroup = New-GraphObject group description 'Just the description'
-$newGroup | Set-GraphResourceItem -TemplateObject $modifiedGroup
+$newGroup | Set-GraphItem -TemplateObject $modifiedGroup
 
 $newGroup | gls -ContentOnly | select displayname, description
 
@@ -514,7 +514,7 @@ Group 7 Access Level Just the description
 Both the `TemplateObject` and `PropertyTable` parameters can be specified simultaneously -- this could be useful for copying parts of one object as a "template" while adding additional properties:
 
 ```powershell
-$existingGroup = Get-GraphResourceItem group -Id 4e5701ac-92b2-42d5-91cf-45f4865d0e70 -ContentOnly
+$existingGroup = Get-GraphItem group -Id 4e5701ac-92b2-42d5-91cf-45f4865d0e70 -ContentOnly
 
 $existingGroup | gls -ContentOnly | select description, displayName
 
@@ -522,9 +522,9 @@ mailNickname displayName description
 ------------ ----------- -----------
              Unused      Unassinged group
 
-$templateGroup = Get-GraphResourceItem group -Id 0b828d58-2f7d-4ec5-92fb-20f0f88aa1a2 -Property displayName, description -ContentOnly
+$templateGroup = Get-GraphItem group -Id 0b828d58-2f7d-4ec5-92fb-20f0f88aa1a2 -Property displayName, description -ContentOnly
 
-$existingGroup | Set-GraphResourceItem -TemplateObject $templateGroup -PropertyTable @{mailNickName='dorateam'}
+$existingGroup | Set-GraphItem -TemplateObject $templateGroup -PropertyTable @{mailNickName='dorateam'}
 
 $existingGroup | gls -ContentOnly | select description, displayName
 
@@ -537,10 +537,10 @@ Finally, an object returned from the Graph may be "edited" locally and then resu
 the `GraphItem` parameter supplied to the pipeline is both the target item to update and the source of data to modify:
 
 ```powershell
-$existingGroup = Get-GraphResourceItem group -Id 4e5701ac-92b2-42d5-91cf-45f4865d0e70 -ContentOnly
+$existingGroup = Get-GraphItem group -Id 4e5701ac-92b2-42d5-91cf-45f4865d0e70 -ContentOnly
 $existingGroup.displayName += ' - ' + [DateTime]::now
 
-$existingGroup | Set-GraphResourceItem
+$existingGroup | Set-GraphItem
 
 $existingGroup | gls -ContentOnly | select description, displayName
 
@@ -549,7 +549,7 @@ description                       displayName
 Standard team collaboration group Team group - 05/16/2019 15:14:41
 ```
 
-Note that `Set-GraphResourceItem` includes an `ExcludeObjectProperty` parameter that allows you to ignore properties specified through `TemplateObject` and `GraphItem` which is useful when the object contains read-only properties that may have been returned as part of an object from a previously executed command.
+Note that `Set-GraphItem` includes an `ExcludeObjectProperty` parameter that allows you to ignore properties specified through `TemplateObject` and `GraphItem` which is useful when the object contains read-only properties that may have been returned as part of an object from a previously executed command.
 
 #### Link resources: add a user to a group (AAD accounts only)
 
@@ -595,11 +595,11 @@ $passwordProfile1 = New-GraphObject passwordprofile -Property forceChangePasswor
 $passwordProfile2 = New-GraphObject passwordprofile -Property forceChangePasswordNextSignIn, password -Value $true, (Get-Credential user).GetNetworkCredential().Password
 
 # Create the actual users
-$newUser1 = New-GraphResourceItem user -Property mailNickname, userPrincipalName, displayname, accountEnabled, passwordProfile -Value vashford, vashford@newnoir.org, 'Val Ashford', $true, $passwordProfile1
-$newUser2 = New-GraphResourceItem user -Property mailNickname, userPrincipalName, displayname, accountEnabled, passwordProfile -Value nsimpson, nsimpson@newnoir.org, 'Nick Simpson', $true, $passwordProfile2
+$newUser1 = New-GraphItem user -Property mailNickname, userPrincipalName, displayname, accountEnabled, passwordProfile -Value vashford, vashford@newnoir.org, 'Val Ashford', $true, $passwordProfile1
+$newUser2 = New-GraphItem user -Property mailNickname, userPrincipalName, displayname, accountEnabled, passwordProfile -Value nsimpson, nsimpson@newnoir.org, 'Nick Simpson', $true, $passwordProfile2
 
 # Create a new group for the users
-$teamGroup = New-GraphResourceItem group mailNickName, displayName, mailEnabled, securityEnabled Group7AccessT1, 'Group 7 Access 2', $false, $true
+$teamGroup = New-GraphItem group mailNickName, displayName, mailEnabled, securityEnabled Group7AccessT1, 'Group 7 Access 2', $false, $true
 
 # Add the users to the group
 $newUser1, $newUser2 | New-GraphItemRelationship $teamGroup members | out-null
@@ -638,26 +638,26 @@ $teamGroup | Get-GraphItemRelationship -WithRelationship members | Remove-GraphI
 
 #### Delete resources
 
-Lastly, the resources we've created can all be deleted using the `Remove-GraphResourceItem` command. This example deletes the group with the id `c436312c-4f6e-4963-ac05-bf68b98d7475`:
+Lastly, the resources we've created can all be deleted using the `Remove-GraphItem` command. This example deletes the group with the id `c436312c-4f6e-4963-ac05-bf68b98d7475`:
 
 ```powershell
-Remove-GraphResourceItem group c436312c-4f6e-4963-ac05-bf68b98d7475
+Remove-GraphItem group c436312c-4f6e-4963-ac05-bf68b98d7475
 ```
 
-The command also takes an object returned by `Get-GraphResourceItem` or `Get-GraphResource`, etc., which is useful for deleting resources accessible only through a relationship with another resource, such as `contact`:
+The command also takes an object returned by `Get-GraphItem` or `Get-GraphResource`, etc., which is useful for deleting resources accessible only through a relationship with another resource, such as `contact`:
 
 ```powershell
 # If you have a variable containing the contact retrieved by an AutoGraphPS
-# command such as Get-GraphResource, New-GraphResourceItem, gls, etc., you can easily
-# delete it by passing it to Remove-GraphResourceItem
-$oldContact | Remove-GraphResourceItem
+# command such as Get-GraphResource, New-GraphItem, gls, etc., you can easily
+# delete it by passing it to Remove-GraphItem
+$oldContact | Remove-GraphItem
 ```
 
 #### Write operation tips and tricks
 
 * Use `Show-GraphHelp` to get the documentation for the Graph resource in which you're interested.
 * Use `Get-GraphType -Members` to view the properties of the type or structure you're updating
-* Use parameter completion with commands like `New-GraphObject`, `New-GraphResourceItem`, `Set-GraphResourceItem`, etc. to ease your workflow and avoid the need to refer to documentation
+* Use parameter completion with commands like `New-GraphObject`, `New-GraphItem`, `Set-GraphItem`, etc. to ease your workflow and avoid the need to refer to documentation
 * Pay attention to error messages from Graph -- these messages will often give useful information about missing or invalid properties so that you can try again, or at least help you navigate a particular help topic.
 * Look for opportunities to use the PowerShell pipeline with AutoGraphPS command for concise, efficient, and scalable automation of Graph resource management.
 
@@ -1081,4 +1081,5 @@ Get-GraphToken | clip
 ```
 
 You can then simply paste it into your tool of choice without having to highlight text or click buttons.
+
 

--- a/src/aliases.ps1
+++ b/src/aliases.ps1
@@ -17,13 +17,15 @@ set-alias gg  Get-Graph
 set-alias ggrel Get-GraphItemRelationship
 set-alias ggreli Get-GraphRelatedItem
 set-alias ggu Get-GraphUriInfo
-set-alias ggci Get-GraphResourceChildItem
-set-alias ggi Get-GraphResourceItem
+set-alias ggci Get-GraphChildItem
+set-alias ggi Get-GraphItem
 set-alias gls Get-GraphResourceWithMetadata
 set-alias gwd Get-GraphLocation
-set-alias gni New-GraphResourceItem
-set-alias grm Remove-GraphResourceItem
-set-alias gsi Set-GraphResourceItem
+set-alias gni New-GraphItem
+set-alias grm Remove-GraphItem
+set-alias gsi Set-GraphItem
 set-alias igm Invoke-GraphMethod
 set-alias ngo New-GraphObject
 set-alias ngp New-GraphMethodParameterObject
+
+

--- a/src/cmdlets.ps1
+++ b/src/cmdlets.ps1
@@ -16,12 +16,12 @@
 . (import-script cmdlets\New-GraphItemRelationship)
 . (import-script cmdlets\Find-GraphPermission)
 . (import-script cmdlets\Get-Graph)
-. (import-script cmdlets\Get-GraphResourceItem)
+. (import-script cmdlets\Get-GraphItem)
 . (import-script cmdlets\Get-GraphItemRelationship)
 . (import-script cmdlets\Get-GraphRelatedItem)
-. (import-script cmdlets\Get-GraphResourceItemUri)
+. (import-script cmdlets\Get-GraphItemUri)
 . (import-script cmdlets\Get-GraphResourceWithMetadata)
-. (import-script cmdlets\Get-GraphResourceChildItem)
+. (import-script cmdlets\Get-GraphChildItem)
 . (import-script cmdlets\Get-GraphLocation)
 . (import-script cmdlets\Get-GraphType)
 . (import-script cmdlets\Get-GraphUri)
@@ -30,21 +30,23 @@
 . (import-script cmdlets\New-Graph)
 . (import-script cmdlets\New-GraphMethodParameterObject)
 . (import-script cmdlets\Remove-Graph)
-. (import-script cmdlets\Remove-GraphResourceItem)
+. (import-script cmdlets\Remove-GraphItem)
 . (import-script cmdlets\Remove-GraphItemRelationship)
-. (import-script cmdlets\Set-GraphResourceItem)
+. (import-script cmdlets\Set-GraphItem)
 . (import-script cmdlets\Set-GraphLocation)
 . (import-script cmdlets\Set-GraphPrompt)
 . (import-script cmdlets\Show-GraphHelp)
 . (import-script cmdlets\Update-GraphMetadata)
 . (import-script cmdlets\New-GraphObject)
-. (import-script cmdlets\New-GraphResourceItem)
+. (import-script cmdlets\New-GraphItem)
 . (import-script cmdlets\Add-GraphRelatedItem)
 
 # Add parameter completion to commands exported by a different module as a UX enhancement
 $::.ParameterCompleter |=> RegisterParameterCompleter Invoke-GraphApiRequest Uri (new-so GraphUriParameterCompleter ([GraphUriCompletionType]::LocationOrMethodUri ))
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResource Uri (new-so GraphUriParameterCompleter ([GraphUriCompletionType]::LocationOrMethodUri ))
 $::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResource Select (new-so TypeUriParameterCompleter Property)
+
+
 
 
 

--- a/src/cmdlets/Add-GraphRelatedItem.ps1
+++ b/src/cmdlets/Add-GraphRelatedItem.ps1
@@ -124,9 +124,9 @@ function Add-GraphRelatedItem {
     end {
 
         if ( $newObjects ) {
-            $newObjects | New-GraphResourceItem -Uri $sourceInfo.Uri @remappedParameters
+            $newObjects | New-GraphItem -Uri $sourceInfo.Uri @remappedParameters
         } else {
-            New-GraphResourceItem -Uri $sourceInfo.Uri @remappedParameters
+            New-GraphItem -Uri $sourceInfo.Uri @remappedParameters
         }
     }
 }
@@ -135,6 +135,7 @@ $::.ParameterCompleter |=> RegisterParameterCompleter Add-GraphRelatedItem TypeN
 $::.ParameterCompleter |=> RegisterParameterCompleter Add-GraphRelatedItem Property (new-so TypeUriParameterCompleter Property $false Property TypeName Relationship)
 $::.ParameterCompleter |=> RegisterParameterCompleter Add-GraphRelatedItem Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
 $::.ParameterCompleter |=> RegisterParameterCompleter Add-GraphRelatedItem GraphName (new-so GraphParameterCompleter)
+
 
 
 

--- a/src/cmdlets/Get-GraphChildItem.ps1
+++ b/src/cmdlets/Get-GraphChildItem.ps1
@@ -19,7 +19,7 @@
 . (import-script common/TypePropertyParameterCompleter)
 . (import-script common/TypeUriParameterCompleter)
 
-function Get-GraphResourceChildItem {
+function Get-GraphChildItem {
     [cmdletbinding(positionalbinding=$false, supportspaging=$true, defaultparametersetname='byuri')]
     param(
         [parameter(position=0, parametersetname='byuri',  mandatory=$true)]
@@ -130,20 +130,22 @@ function Get-GraphResourceChildItem {
         $ignoreProperty = $SkipPropertyCheck.IsPresent -or ( $Relationship -ne $null )
 
         if ( $accumulatedItems ) {
-            $accumulatedItems | Get-GraphResourceItem @remappedParameters -SkipPropertyCheck:$ignoreProperty -ChildrenOnly:$true
+            $accumulatedItems | Get-GraphItem @remappedParameters -SkipPropertyCheck:$ignoreProperty -ChildrenOnly:$true
         } else {
             foreach ( $remappedUri in $remappedUris ) {
-                Get-GraphResourceItem -Uri $remappedUri @remappedParameters -ChildrenOnly:$true -SkipPropertyCheck:$ignoreProperty
+                Get-GraphItem -Uri $remappedUri @remappedParameters -ChildrenOnly:$true -SkipPropertyCheck:$ignoreProperty
             }
         }
     }
 }
 
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceChildItem Uri (new-so GraphUriParameterCompleter LocationOrMethodUri)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceChildItem TypeName (new-so TypeUriParameterCompleter TypeName $false)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceChildItem Property (new-so TypeUriParameterCompleter Property $false)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceChildItem Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceChildItem OrderBy (new-so TypeUriParameterCompleter Property)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceChildItem Expand (new-so TypeUriParameterCompleter Property $false NavigationProperty)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceChildItem GraphName (new-so GraphParameterCompleter)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem Uri (new-so GraphUriParameterCompleter LocationOrMethodUri)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem TypeName (new-so TypeUriParameterCompleter TypeName $false)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem Property (new-so TypeUriParameterCompleter Property $false)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem OrderBy (new-so TypeUriParameterCompleter Property)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem Expand (new-so TypeUriParameterCompleter Property $false NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphChildItem GraphName (new-so GraphParameterCompleter)
+
+
 

--- a/src/cmdlets/Get-GraphItem.ps1
+++ b/src/cmdlets/Get-GraphItem.ps1
@@ -20,7 +20,7 @@
 . (import-script common/TypePropertyParameterCompleter)
 . (import-script common/TypeUriParameterCompleter)
 
-function Get-GraphResourceItem {
+function Get-GraphItem {
     [cmdletbinding(positionalbinding=$false, supportspaging=$true, defaultparametersetname='byuri')]
     param(
         [parameter(position=0, parametersetname='byuri', mandatory=$true)]
@@ -149,10 +149,11 @@ function Get-GraphResourceItem {
     }
 }
 
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceItem TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceItem Property (new-so TypeUriParameterCompleter Property)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceItem OrderBy (new-so TypeUriParameterCompleter Property)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceItem Expand (new-so TypeUriParameterCompleter Property $false NavigationProperty)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceItem GraphName (new-so GraphParameterCompleter)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceItem Uri (new-so GraphUriParameterCompleter ([GraphUriCompletionType]::LocationOrMethodUri ))
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem TypeName (new-so TypeUriParameterCompleter TypeName)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem Property (new-so TypeUriParameterCompleter Property)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem OrderBy (new-so TypeUriParameterCompleter Property)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem Expand (new-so TypeUriParameterCompleter Property $false NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem GraphName (new-so GraphParameterCompleter)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItem Uri (new-so GraphUriParameterCompleter ([GraphUriCompletionType]::LocationOrMethodUri ))
+
 

--- a/src/cmdlets/Get-GraphItemUri.ps1
+++ b/src/cmdlets/Get-GraphItemUri.ps1
@@ -18,7 +18,7 @@
 . (import-script common/TypeParameterCompleter)
 . (import-script common/TypeUriParameterCompleter)
 
-function Get-GraphResourceItemUri {
+function Get-GraphItemUri {
     [cmdletbinding(positionalbinding=$false, defaultparametersetname='fromtype')]
     param(
         [parameter(position=0, parametersetname='fromtype', mandatory=$true)]
@@ -124,8 +124,9 @@ function Get-GraphResourceItemUri {
     }
 }
 
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceItemUri TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceItemUri Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceItemUri GraphName (new-so GraphParameterCompleter)
-$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphResourceItemUri Uri (new-so GraphUriParameterCompleter LocationUri)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItemUri TypeName (new-so TypeUriParameterCompleter TypeName)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItemUri Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItemUri GraphName (new-so GraphParameterCompleter)
+$::.ParameterCompleter |=> RegisterParameterCompleter Get-GraphItemUri Uri (new-so GraphUriParameterCompleter LocationUri)
+
 

--- a/src/cmdlets/New-GraphItem.ps1
+++ b/src/cmdlets/New-GraphItem.ps1
@@ -19,7 +19,7 @@
 . (import-script common/TypePropertyParameterCompleter)
 . (import-script common/TypeUriParameterCompleter)
 
-function New-GraphResourceItem {
+function New-GraphItem {
     [cmdletbinding(positionalbinding=$false, defaultparametersetname='bytypeoptionallyqualified')]
     param(
         [parameter(position=0, parametersetname='bytypeoptionallyqualified', mandatory=$true)]
@@ -169,10 +169,11 @@ function New-GraphResourceItem {
     end {}
 }
 
-$::.ParameterCompleter |=> RegisterParameterCompleter New-GraphResourceItem TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter New-GraphResourceItem Property (new-so TypeUriParameterCompleter Property $false Property TypeName Relationship)
-$::.ParameterCompleter |=> RegisterParameterCompleter New-GraphResourceItem Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
-$::.ParameterCompleter |=> RegisterParameterCompleter New-GraphResourceItem GraphName (new-so GraphParameterCompleter)
+$::.ParameterCompleter |=> RegisterParameterCompleter New-GraphItem TypeName (new-so TypeUriParameterCompleter TypeName)
+$::.ParameterCompleter |=> RegisterParameterCompleter New-GraphItem Property (new-so TypeUriParameterCompleter Property $false Property TypeName Relationship)
+$::.ParameterCompleter |=> RegisterParameterCompleter New-GraphItem Relationship (new-so TypeUriParameterCompleter Property $false NavigationProperty)
+$::.ParameterCompleter |=> RegisterParameterCompleter New-GraphItem GraphName (new-so GraphParameterCompleter)
+
 
 
 

--- a/src/cmdlets/Remove-GraphItem.ps1
+++ b/src/cmdlets/Remove-GraphItem.ps1
@@ -19,9 +19,9 @@
 . (import-script common/TypeParameterCompleter)
 . (import-script common/TypePropertyParameterCompleter)
 . (import-script common/TypeUriParameterCompleter)
-. (import-script Get-GraphResourceItem)
+. (import-script Get-GraphItem)
 
-function Remove-GraphResourceItem {
+function Remove-GraphItem {
     [cmdletbinding(positionalbinding=$false, defaultparametersetname='byuri')]
     param(
         [parameter(position=0, parametersetname='byuri', mandatory=$true)]
@@ -87,7 +87,8 @@ function Remove-GraphResourceItem {
     end {}
 }
 
-$::.ParameterCompleter |=> RegisterParameterCompleter Remove-GraphResourceItem TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter Remove-GraphResourceItem GraphName (new-so GraphParameterCompleter)
+$::.ParameterCompleter |=> RegisterParameterCompleter Remove-GraphItem TypeName (new-so TypeUriParameterCompleter TypeName)
+$::.ParameterCompleter |=> RegisterParameterCompleter Remove-GraphItem GraphName (new-so GraphParameterCompleter)
+
 
 

--- a/src/cmdlets/Set-GraphItem.ps1
+++ b/src/cmdlets/Set-GraphItem.ps1
@@ -20,7 +20,7 @@
 . (import-script common/TypePropertyParameterCompleter)
 . (import-script common/TypeUriParameterCompleter)
 
-function Set-GraphResourceItem {
+function Set-GraphItem {
     [cmdletbinding(positionalbinding=$false, defaultparametersetname='byuri')]
     param(
         [parameter(position=0, parametersetname='byuri', mandatory=$true)]
@@ -139,9 +139,10 @@ function Set-GraphResourceItem {
     end {}
 }
 
-$::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphResourceItem TypeName (new-so TypeUriParameterCompleter TypeName)
-$::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphResourceItem Property (new-so TypeUriParameterCompleter Property $false)
-$::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphResourceItem ExcludeObjectProperty (new-so TypeUriParameterCompleter Property $false Property $null $null GraphObject)
-$::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphResourceItem GraphName (new-so GraphParameterCompleter)
+$::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphItem TypeName (new-so TypeUriParameterCompleter TypeName)
+$::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphItem Property (new-so TypeUriParameterCompleter Property $false)
+$::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphItem ExcludeObjectProperty (new-so TypeUriParameterCompleter Property $false Property $null $null GraphObject)
+$::.ParameterCompleter |=> RegisterParameterCompleter Set-GraphItem GraphName (new-so GraphParameterCompleter)
+
 
 

--- a/src/cmdlets/Set-GraphItem.tests.ps1
+++ b/src/cmdlets/Set-GraphItem.tests.ps1
@@ -17,10 +17,10 @@ set-strictmode -version 2
 . (join-path $psscriptroot ../../test/common/GetParameterTestFunction.ps1)
 . (join-path $psscriptroot ../../test/common/NoninteractiveSubtestHelper.ps1)
 
-Describe 'The Set-GraphResourceItem command parameterbinding behavior' -tag parameterbinding {
+Describe 'The Set-GraphItem command parameterbinding behavior' -tag parameterbinding {
     Context 'When binding parameters with validation that is only possible if powershell is launched as non-interactive' {
         BeforeAll {
-            GetParameterTestFunction Set-GraphResourceItem | new-item function:Set-GraphResourceItemTest
+            GetParameterTestFunction Set-GraphItem | new-item function:Set-GraphItemTest
             $contentObject = [PSCustomObject] @{Id='objectid'}
             $standardObject = [PSCustomObject] @{
                 Id = 'objectid'
@@ -33,21 +33,21 @@ Describe 'The Set-GraphResourceItem command parameterbinding behavior' -tag para
         It "Should bind to the typeandid parameter set when type, id, property, and value are specified as named" {
             $parameterSetTestsFinished | Should Not Be $null
             if ( ! $parameterSetTestsFinished ) {
-                Set-GraphResourceItemTest -typename type1 -id id -property propname -value valname| select -expandproperty ParameterSetName | should be 'bytypeandid'
+                Set-GraphItemTest -typename type1 -id id -property propname -value valname| select -expandproperty ParameterSetName | should be 'bytypeandid'
             }
         }
 
         It "Should bind to the typeandid parameter set when type, id, property, and value are specified as named" {
             $parameterSetTestsFinished | Should Not Be $null
             if ( ! $parameterSetTestsFinished ) {
-                Set-GraphResourceItemTest -typename type1 -id id -property propname -value valname| select -expandproperty ParameterSetName | should be 'bytypeandid'
+                Set-GraphItemTest -typename type1 -id id -property propname -value valname| select -expandproperty ParameterSetName | should be 'bytypeandid'
             }
         }
 
         It "Should bind to the byuri parameter set when the first parameter is positional and no id parameter is specified" {
             $parameterSetTestsFinished | Should Not Be $null
             if ( ! $parameterSetTestsFinished ) {
-                $bindingInfo = Set-GraphResourceItemTest me -property propname -value valname
+                $bindingInfo = Set-GraphItemTest me -property propname -value valname
 
                 $bindingInfo.ParameterSetName | Should Be 'byuri'
                 $bindingInfo.BoundParameters['Uri'] | Should Be 'me'
@@ -58,7 +58,7 @@ Describe 'The Set-GraphResourceItem command parameterbinding behavior' -tag para
         It "Should bind to the byobject parameterset when an unwrapped object is specified to the pipeline and value and property parameters are specified by name" {
             $parameterSetTestsFinished | Should Not Be $null
             if ( ! $parameterSetTestsFinished ) {
-                $bindingInfo = $contentObject | Set-GraphResourceItemTest -property propname -value valname
+                $bindingInfo = $contentObject | Set-GraphItemTest -property propname -value valname
 
                 $bindingInfo.parametersetname | Should Be 'byobject'
                 $bindingInfo.BoundParameters['GraphItem'].Id | Should Be $contentObject.Id
@@ -68,7 +68,7 @@ Describe 'The Set-GraphResourceItem command parameterbinding behavior' -tag para
         It "Should bind to the byobject parameterset when a wrapped object is specified to the pipeline and value and property parameters are specified by name" {
             $parameterSetTestsFinished | Should Not Be $null
             if ( ! $parameterSetTestsFinished ) {
-                $bindingInfo = $standardObject | Set-GraphResourceItemTest -property propname -value valname
+                $bindingInfo = $standardObject | Set-GraphItemTest -property propname -value valname
 
                 $bindingInfo.parametersetname | Should Be 'byobject'
                 $bindingInfo.BoundParameters['GraphItem'].Id | Should Be $standardObject.Id
@@ -78,7 +78,7 @@ Describe 'The Set-GraphResourceItem command parameterbinding behavior' -tag para
         It "Should bind to the byobject parameterset when a wrapped object is specified to the pipeline and no other parameters are specified" {
             $parameterSetTestsFinished | Should Not Be $null
             if ( ! $parameterSetTestsFinished ) {
-                $bindingInfo = $standardObject | Set-GraphResourceItemTest
+                $bindingInfo = $standardObject | Set-GraphItemTest
 
                 $bindingInfo.parametersetname | Should Be 'byobject'
                 $bindingInfo.BoundParameters['GraphItem'].Id | Should Be $standardObject.Id
@@ -88,7 +88,7 @@ Describe 'The Set-GraphResourceItem command parameterbinding behavior' -tag para
         It "Should bind to the byobject parameterset when a wrapped object is specified to the pipeline and the MergeGraphItemWithPropertyTable and PropertyTable parameters are specified" {
             $parameterSetTestsFinished | Should Not Be $null
             if ( ! $parameterSetTestsFinished ) {
-                $bindingInfo = $standardObject | Set-GraphResourceItemTest -MergeGraphItemWithPropertyTable -PropertyTable @{prop3='propval3'}
+                $bindingInfo = $standardObject | Set-GraphItemTest -MergeGraphItemWithPropertyTable -PropertyTable @{prop3='propval3'}
 
                 $bindingInfo.parametersetname | Should Be 'byobject'
                 $bindingInfo.BoundParameters['GraphItem'].Id | Should Be $standardObject.Id
@@ -100,7 +100,7 @@ Describe 'The Set-GraphResourceItem command parameterbinding behavior' -tag para
         It "Should bind to the bytypeandid parameterset when a type is specified as positional and id, property, and value are named" {
             $parameterSetTestsFinished | Should Not Be $null
             if ( ! $parameterSetTestsFinished ) {
-                $bindingInfo = Set-GraphResourceItemTest user -id userid -property propname -value valdata
+                $bindingInfo = Set-GraphItemTest user -id userid -property propname -value valdata
 
                 $bindingInfo.parametersetname | Should Be 'bytypeandid'
 
@@ -112,20 +112,21 @@ Describe 'The Set-GraphResourceItem command parameterbinding behavior' -tag para
         }
     }
 
-    Context 'When invoking Set-GraphResourceItem' {
+    Context 'When invoking Set-GraphItem' {
         BeforeAll {
             $progresspreference = 'silentlycontinue'
             Update-GraphMetadata -Path "$psscriptroot/../../test/assets/microsoft-directoryservices-fragment.xml" -force -wait -warningaction silentlycontinue
         }
 
         It "Should throw an exception when value is specified but property is not specified" {
-            { Set-GraphResourceItem microsoft.graph.user -id id -value valnoprop | select -expandproperty ParameterSetName } | Should Throw "the Property parameter must also be specified"
+            { Set-GraphItem microsoft.graph.user -id id -value valnoprop | select -expandproperty ParameterSetName } | Should Throw "the Property parameter must also be specified"
         }
 
         It "Should throw an exception when Value is specified but has a larger size than Property" {
-            { Set-GraphResourceItem microsoft.graph.user -id id -property propname -value val1, val2 | select -expandproperty ParameterSetName } | Should Throw "must be less than the specified"
+            { Set-GraphItem microsoft.graph.user -id id -property propname -value val1, val2 | select -expandproperty ParameterSetName } | Should Throw "must be less than the specified"
         }
     }
 }
+
 
 


### PR DESCRIPTION
### Description

Fixes command name conflict with AutoGraphPS-SDK dependency for the `Remove-GraphItem` command, and undoes the renaming of several commands in this module incorrectly undertaken when the `Remove-GraphItem` conflict was misunderstood to be due to community usage rather than a defect in a dependency.

### New dependencies

* AutoGraphPS-SDK 0.24.0

### Breaking changes

* The following commands are renamed back to what they were prior to an incorrect rename in the version of this module (0.33.0) prior to this one:
  Get-GraphResourceChildItem -> Get-GraphChildItem
  Get-GraphResourceItem -> Get-GraphItem
  Get-GraphResourceItemUri -> Get-GraphItemUri
  New-GraphResourceItem -> New-GraphItem
  Remove-GraphResourceItem -> Remove-GraphItem
  Set-GraphResourceItem -> Set-GraphItem

None.

### New features

None.

### Fixed defects

* At installation time the module would complain of a conflict with `Remove-GraphItem` which is exposed by this module. It turns out that while an earlier version of `AutoGraphPS-SDK` had exported an identically-named command but had renamed it to `Remove-GraphResource`, the rename process was incomplete and `AutoGraphPS-SDK` was still exporting this command. The fix for this module is to include an updated version of `AutoGraphPS-SDK` that no longer exports `Remove-GraphItem` and does export `Remove-GraphResource`.

### Checklist

- [ ] All project tests pass successfully
