### PR TITLE
Documentation updates, autographps-sdk dependency update with breaking changes, pipeline fixes for Show-GraphHelp

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you have ideas on how to improve **AutoGraphPS**, please consider [opening an
 
 ### System requirements
 
-On the Windows operating system, PowerShell 5.1 and higher are supported. On Linux, PowerShell 6.1.2 and higher are supported. MacOS has not been tested, but should work with PowerShell 6.1.2 and higher.
+On the Windows operating system, PowerShell 5.1 and higher are supported. On Linux and MacOS, PowerShell 6.1.2 and higher are supported.
 
 ## Installation
 AutoGraphPS is available through the [PowerShell Gallery](https://www.powershellgallery.com/packages/autographps); run the following command to install the latest stable release of AutoGraphPS into your user profile:
@@ -241,20 +241,20 @@ $newContact | Remove-GraphItem
 
 Subsequent attempts to retrieve the entity from the Graph by identifier or URI using commands such as `Get-GraphItem` or `Get-GraphResource` will fail because the entity has been deleted by `Remove-GraphItem`.
 
-##### Invoke-GraphRequest handles all the REST
+##### Invoke-GraphApiRequest handles all the REST
 
-What if you can't find exactly the command you need to interact with the Graph? The `Invoke-GraphRequest` is a general-purpose command that, with the right parameters, can emulate any of the other commands that interact with Graph. It is a generic REST client capable of issuing any valid request to the Graph. You can use it if you run into a scenario that isn't covered by the other commmands. In general it may be useful if you're already using REST to interact with the Graph.
+What if you can't find exactly the command you need to interact with the Graph? The `Invoke-GraphApiRequest` is a general-purpose command that, with the right parameters, can emulate any of the other commands that interact with Graph. It is a generic REST client capable of issuing any valid request to the Graph. You can use it if you run into a scenario that isn't covered by the other commmands. In general it may be useful if you're already using REST to interact with the Graph.
 
 Here's one example that issues the same request as in the earlier example for `New-GraphItem':
 
 ```powershell
 $contactData = @{givenName='Cleopatra Jones';emailAddresses=@(@{name='Work';Address='cleo@soulsonic.org'})}
-Invoke-GraphRequest -Method POST me/contacts -Body $contactData
+Invoke-GraphApiRequest -Method POST me/contacts -Body $contactData
 ```
 
-As its name suggests, the `Method` parameter of `Invoke-GraphRequest` lets you specify any **REST** method, i.e. `PUT`, `POST`, `PATCH`, and `DELETE`. Thus `Invoke-GraphRequest` is capable of executing any capability of Graph and can be considered *the universal Graph command.* The example given here is less readable than the `New-GraphObject` / `New-GraphItem` example and requires you to know more about the underlying Graph protocol (e.g that creation of data usually means you must use the `POST` method), but it is consistent with the idea that if you can't find the command you need, you can always find a way to get things working with `Invoke-GraphRequest`, even if it trades off simplicity.
+As its name suggests, the `Method` parameter of `Invoke-GraphApiRequest` lets you specify any **REST** method, i.e. `PUT`, `POST`, `PATCH`, and `DELETE`. Thus `Invoke-GraphApiRequest` is capable of executing any capability of Graph and can be considered *the universal Graph command.* The example given here is less readable than the `New-GraphObject` / `New-GraphItem` example and requires you to know more about the underlying Graph protocol (e.g that creation of data usually means you must use the `POST` method), but it is consistent with the idea that if you can't find the command you need, you can always find a way to get things working with `Invoke-GraphApiRequest`, even if it trades off simplicity.
 
-Note that the `Body` parameter allows you to specify the JSON body of the request which typically describes the information to write. In the example above, rather than specify the JSON directly, we chose to express it as a PowerShell `HashTable` object. When the `Body` parameter is not a JSON string, `Invoke-GraphRequest` converts whatever type you specify to JSON for you. The way the `HashTable` was structured in this example allowed it to be serialized into exactly the JSON format required to `POST` a `contact` object to `/me/contacts` as a well-formed request.
+Note that the `Body` parameter allows you to specify the JSON body of the request which typically describes the information to write. In the example above, rather than specify the JSON directly, we chose to express it as a PowerShell `HashTable` object. When the `Body` parameter is not a JSON string, `Invoke-GraphApiRequest` converts whatever type you specify to JSON for you. The way the `HashTable` was structured in this example allowed it to be serialized into exactly the JSON format required to `POST` a `contact` object to `/me/contacts` as a well-formed request.
 
 #### So how do I find all the URIs and JSON for Graph?
 
@@ -284,7 +284,7 @@ https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/resources/us
 #### AutoGraphPS tips
 Here are a few simple tips to keep in mind as you first start using AutoGraphPS:
 
-**1. Permissions matter:** AutoGraphPS can only access parts of the Graph for which you (or your organization's administrator) have given consent. Use the `Connnect-Graph` cmdlet to request additional permissions for AutoGraphPS, particularly if you run into authorization errors. Also, consult the [Graph permissions documentation](https://developer.microsoft.com/en-us/graph/docs/concepts/permissions_reference) to understand what permissions are required for particular subsets of the Graph. Note that if you're using an Azure Active Directory account to access the Graph, you may need your organization's administrator to consent to the permissions on your behalf in order to grant them to AutoGraphPS.
+**1. Permissions matter:** AutoGraphPS can only access parts of the Graph for which you (or your organization's administrator) have given consent. Use the `Connnect-Graph` cmdlet to request additional permissions for AutoGraphPS, particularly if you run into authorization errors. Also, consult the [Graph permissions documentation](https://docs.microsoft.com/en-us/graph/permissions-reference) to understand what permissions are required for particular subsets of the Graph. Note that if you're using an Azure Active Directory account to access the Graph, you may need your organization's administrator to consent to the permissions on your behalf in order to grant them to AutoGraphPS.
 
 **2. Use tab-completion to learn and save time:** Many AutoGraphPS commands, including `Get-GraphResource`, `gls`, and `gcd` will tab-complete command parameters just like many other popular PowerShell commands do. URIs, resource names, and permission names are just some of the kinds of parameters that AutoGraphPS will tab-complete for you to reduce the time needed to issue a command and also clue you in on when you're potentially providing invalid input.
 
@@ -348,14 +348,14 @@ Note that since AutoGraphPS is built on [AutoGraphPS-SDK](https://github.com/ada
 | Get-GraphToken            | Gets an access token for the Graph -- helpful in using other tools such as [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer)  |
 | Get-GraphType             | Gets metadata for the specified resource type as documented in the [Graph reference](https://developer.microsoft.com/en-us/graph/docs/concepts/v1-overview)         |
 | Get-GraphUriInfo (ggu)    | Gets detailed metadata about the segments of a Graph Uri or child segments of the Uri                   |
-| Invoke-GraphRequest       | Executes a REST method (e.g. `GET`, `PUT`, `POST`, `DELETE`, etc.) for a Graph Uri                      |
+| Invoke-GraphApiRequest       | Executes a REST method (e.g. `GET`, `PUT`, `POST`, `DELETE`, etc.) for a Graph Uri                      |
 | Invoke-GraphMethod        | Executes a method on a given Graph object specified by Type and Id or URI                               |
 | New-Graph                 | Mounts a new Graph connection and associated metadata for availability to AutoGraphPS cmdlets           |
 | New-GraphApplication      | Creates an Azure AD application configured to authenticate to Microsoft Graph                           |
 | New-GraphApplicationCertificate | Creates a new certificate in the local certificate store and configures its public key on an application |
 | New-GraphConnection       | Creates an authenticated connection using advanced identity customizations for accessing a Graph        |
 | New-GraphMethodParameter  | Creates a local representation of a Graph type for the specified parameter of a specified Graph method  |
-| New-GraphObject           | Creates a local representation of a type defined by the Graph API that can be specified in the body of write requests in commands such as `Invoke-GraphRequest` |
+| New-GraphObject           | Creates a local representation of a type defined by the Graph API that can be specified in the body of write requests in commands such as `Invoke-GraphApiRequest` |
 | New-GraphItem     | Creates an instance of the specified entity type in the Graph given a set of properties |
 | Register-GraphApplication | Creates a registration in the tenant for an existing Azure AD application    |
 | Remove-Graph              | Unmounts a Graph previously mounted by `NewGraph`                                                       |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,6 +2,7 @@
 
 ## To-do items -- prioritized
 
+* Add 'graph' search index: find by navigation property type (rather than name), i.e. types referring to this type
 * Commands to manage open extensions
 * Fix ambiguous new object problem
 * Add DefaultUriForType to Get-GraphType
@@ -354,6 +355,7 @@
 * Use Start-ThreadJob instead of Start-Job for background metadata processing
 * pipeline support for get-graphtype
 * Graph statistics command
+* Allow types to be piped to show-graphhelp from find-graphtype
 
 ### Postponed
 
@@ -375,6 +377,7 @@
 * Rename graphscope to graphname on get-graphuriinfo
 * Show-GraphHelp should take a uri
 * Get-GraphType should take a URI
+* Make show-graphhelp support pipeline
 
 ### Abandoned
 

--- a/autographps.nuspec
+++ b/autographps.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright 2020</copyright>
     <tags>MSGraph Graph Directory PSModule</tags>
     <dependencies>
-      <dependency id="autographps-sdk" version="0.24.0" />
+      <dependency id="autographps-sdk" version="0.25.0" />
     </dependencies>
   </metadata>
   <files>

--- a/autographps.psd1
+++ b/autographps.psd1
@@ -27,10 +27,10 @@ Author = 'Adam Edwards'
 CompanyName = 'Modulus Group'
 
 # Copyright statement for this module
-Copyright = '(c) 2020 Adam Edwards.'
+Copyright = '(c) 2021 Adam Edwards.'
 
 # Description of the functionality provided by this module
-Description = 'CLI for automating and exploring the Microsoft Graph'
+Description = 'The friendly, scriptable Graph Explorer CLI for automating the Microsoft Graph'
 
 # Minimum version of the Windows PowerShell engine required by this module
 PowerShellVersion = '5.1'
@@ -67,7 +67,7 @@ FormatsToProcess = @('./src/cmdlets/common/AutoGraphFormats.ps1xml')
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 NestedModules = @(
-    @{ModuleName='autographps-sdk';ModuleVersion='0.24.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
+    @{ModuleName='autographps-sdk';ModuleVersion='0.25.0';Guid='4d32f054-da30-4af7-b2cc-af53fb6cb1b6'}
     @{ModuleName='scriptclass';ModuleVersion='0.20.2';Guid='9b0f5599-0498-459c-9a47-125787b1af19'}
     @{ModuleName='ThreadJob';ModuleVersion='2.0.3';Guid='0e7b895d-2fec-43f7-8cae-11e8d16f6e40'}
 )
@@ -253,11 +253,14 @@ Adds additional commands to make type inspection more usable.
 
 ### New dependencies
 
-None.
+* `autographps-sdk 0.25.0`
+  * Including that dependency's update to Microsoft Authentication Library (MSAL) 4.27
 
 ### Breaking changes
 
-None.
+* Old default appid is deprecated, superseded with new appid ac70e3e2-a821-4d19-839c-b8af4515254b. Impact includes the need to re-consent to any desired permissions that were granted to the previous appid.
+* When signing in with an app other than the default appid, personal Microsoft Accounts cannot sign in without specifying `AllowMSA` via `Connect-GraphApi`
+* `New-GraphApplication` now creates single tenant applications by default for public client apps
 
 ### New features
 
@@ -266,6 +269,10 @@ None.
   * `Get-GraphMethod`: This command gets the methods of a Graph object's type or an explicitly specified type name. The output includes the return type (if any) of the method and the named parameters of the method and their types.
   * `Find-GraphType`: This command returns the types that match specified criteria. This is useful for finding types that can be used to accomplish tasks in the problem domain represented by the search terms.
   * `Get-GraphType` now accepts objects from the pipeline.
+* From updated `autographpsd-sdk` dependency:
+  * `Connect-GraphApi` and `New-GraphConnection` support the `AllowMSA` parameter to enable MSA accounts when signing in with an app other than the default app
+  * Objects emitted by `Invoke-GraphApiRequest` and related commands now have a type `GraphResponseObject` included in `PSTypeNames` to enable reliable pipeline binding and eventual improvements in output formatting.
+
 
 ### Fixed defects
 
@@ -273,6 +280,11 @@ None.
 * For some types, such as driveItem, the output of Get-GraphType would show duplicate methods for methods like getActivityByInterval -- now only one version of the method is returned (a type cannot have two methods with the same name).
 * Get-Graph was returning non-canonical file paths for the LastTypeMetadataSource property when commands like Update-GraphMetadata were used to obtain metadata from a file
 None.
+  * From `autographpsd-sdk` dependency:
+  * [Many scenarios broken for Microsoft Accounts only but not broken for AAD accounts](https://github.com/adamedx/autographps-sdk/issues/53)
+  * Sign-in for single tenant applications was broken
+  * Error response streams were not being retrieved, so detailed errors were missing from Get-GraphLog and other error-surfacing mechanisms
+  * `Get-GraphLog` was emitting errors in the wrong order with oldest first rather than newest first
 
 '@
     } # End of PSData hashtable

--- a/src/cmdlets/Get-GraphType.ps1
+++ b/src/cmdlets/Get-GraphType.ps1
@@ -109,7 +109,11 @@ function Get-GraphType {
                 }
             }
 
-            $result = $::.TypeHelper |=> ToPublic $type
+            $defaultUri = if ( $type.Class -eq 'Entity' ) {
+                $::.TypeUriHelper |=> DefaultUriForType $targetContext $type.TypeId
+            }
+
+            $result = $::.TypeHelper |=> ToPublic $type $defaultUri
 
             if ( ! $TransitiveMembers.IsPresent ) {
                 $result | sort-object name

--- a/src/cmdlets/common/TypeHelper.ps1
+++ b/src/cmdlets/common/TypeHelper.ps1
@@ -24,6 +24,7 @@ ScriptClass TypeHelper {
             Namespace = 'Namespace'
             TypeClass = 'Class'
             BaseType = 'BaseType'
+            DefaultUri = 'DefaultUri'
             Properties = 'Properties'
             RelationshipNames = 'PropertyNames'
             Relationships = 'NavigationProperties'
@@ -36,7 +37,7 @@ ScriptClass TypeHelper {
             __RegisterDisplayType
         }
 
-        function ToPublic( $privateObject ) {
+        function ToPublic( $privateObject, $defaultUri ) {
             $properties = ($::.MemberDisplayType |=> ToDisplayableMemberList $privateObject.($this.displayProperties.Properties)).Result
             $relationships = ($::.MemberDisplayType |=> ToDisplayableMemberList $privateObject.($this.displayProperties.Relationships)).Result
             $methods = ($::.MemberDisplayType |=> ToDisplayableMemberList $privateObject.($this.displayProperties.Methods)).Result
@@ -48,6 +49,7 @@ ScriptClass TypeHelper {
                 Namespace = $privateObject.($this.displayProperties.Namespace)
                 TypeClass = $privateObject.($this.displayProperties.TypeClass)
                 BaseType = $privateObject.($this.displayProperties.BaseType)
+                DefaultUri = $defaultUri
                 RelationshipNames = $relationshipNames
                 IsComposite = $privateObject.($this.displayProperties.IsComposite)
                 NativeSchema = $privateObject.($this.displayProperties.NativeSchema)
@@ -63,7 +65,7 @@ ScriptClass TypeHelper {
         function __RegisterDisplayType {
             remove-typedata -typename $this.DisplayTypeName -erroraction ignore
 
-            $coreProperties = @('TypeId', 'TypeClass', 'BaseType', 'RelationshipNames')
+            $coreProperties = @('TypeId', 'TypeClass', 'BaseType', 'DefaultUri', 'Relationships', 'Properties', 'Methods')
 
             $displayTypeArguments = @{
                 TypeName = $this.DisplayTypeName


### PR DESCRIPTION
### Description

Includes breaking changes, bug fixes, and features from commands exposed by the `AutoGraphPS-SDK` module as well as some improvements in using the pipeline with `Show-GraphHelp`. Scenario documentation in the repository is also updated to reflect new commands and add coverage for pre-existing commands.

### New dependencies

* `autographps-sdk 0.25.0`
  * Including that dependency's update to Microsoft Authentication Library (MSAL) 4.27

### Breaking changes

* From autographps-sdk:
  * Old default appid is deprecated, superseded with new appid ac70e3e2-a821-4d19-839c-b8af4515254b. Impact includes the need to re-consent to any desired permissions that were granted to the previous appid.
  * When signing in with an app other than the default appid, personal Microsoft Accounts cannot sign in without specifying `AllowMSA` via `Connect-GraphApi`
  
### New features

* From updated `autographpsd-sdk` dependency:
  * `Connect-GraphApi` and `New-GraphConnection` support the `AllowMSA` parameter to enable MSA accounts when signing in with an app other than the default app
  * Objects emitted by `Invoke-GraphApiRequest` and related commands now have a type `GraphResponseObject` included in `PSTypeNames` to enable reliable pipeline binding and eventual improvements in output formatting.

### Fixed defects

  * From `autographpsd-sdk` dependency:
  * [Many scenarios broken for Microsoft Accounts only but not broken for AAD accounts](https://github.com/adamedx/autographps-sdk/issues/53)
  * Sign-in for single tenant applications was broken
  * Error response streams were not being retrieved, so detailed errors were missing from Get-GraphLog and other error-surfacing mechanisms
  * `Get-GraphLog` was emitting errors in the wrong order with oldest first rather than newest first

### Checklist

- [x] New test coverage was added for the new functionality
- [x] All project tests pass successfully
